### PR TITLE
fix: cross-package schema review findings (v1.4.1)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,29 @@ All notable changes to pyGAEB are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-03-15
+
+### Added
+
+- **Shared Catalog Module** — `CtlgAssign` and `Catalog` moved to `pygaeb.models.catalog` for cross-package reuse
+- `ctlg_assigns` field on `Item`, `BoQCtgy`, `BoQInfo`, `CostElement`, and `ECCtgy`
+- `CtlgAssign` parsing in procurement (`_parse_item`, `_parse_ctgy`, `_parse_boq_info`), cost (`CostElement`, `ECCtgy`), and trade (`TradeOrder`, `OrderInfo`, `OrderItem`)
+- `CtlgAssign` serialization in procurement writer (items, categories, BoQInfo) and trade writer (Order, OrderInfo, OrderItem)
+- `ctlg_assigns` field on `OrderItem`, `OrderInfo`, and `TradeOrder`
+- **Phase-specific procurement namespace** — `procurement_namespace()` helper; writer output now uses `DA83/3.3` for X83, `DA84/3.3` for X84, etc. (was hardcoded `DA86`)
+- DA XML 3.0 and earlier correctly falls back to the fixed `200407` namespace
+- **MarkupItem support (X52)** — `<MarkupItem>` elements parsed as `Item` with `ItemType.MARKUP`
+- `MarkupSubQty` model for markup sub-quantity references
+- `markup_type` and `markup_sub_qtys` fields on `Item`
+- `_add_markup_item()` writer function for round-trip `<MarkupItem>` serialization
+- 33 new tests covering all findings (including trade CtlgAssign)
+- `MarkupSubQty` added to top-level `__all__` exports
+
+### Fixed
+
+- Procurement writer namespace no longer hardcodes `DA86` — each exchange phase gets its correct namespace
+- `CtlgAssign` and `Catalog` no longer tied to `pygaeb.models.quantity`; re-exported for backward compatibility
+
 ## [1.4.0] - 2026-03-15
 
 ### Added
@@ -107,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `py.typed` marker for PEP 561 compliance
 - Comprehensive test suite (193 tests)
 
+[1.4.1]: https://github.com/frameiq/pygaeb/releases/tag/v1.4.1
 [1.4.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.4.0
 [1.3.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.3.0
 [1.2.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.2.0

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -98,6 +98,11 @@ The unified domain model that all parser tracks produce. Documents are **procure
       show_root_heading: true
       members_order: source
 
+::: pygaeb.models.item.MarkupSubQty
+    options:
+      show_root_heading: true
+      members_order: source
+
 ::: pygaeb.models.item.ValidationResult
     options:
       show_root_heading: true
@@ -254,17 +259,21 @@ The unified domain model that all parser tracks produce. Documents are **procure
       show_root_heading: true
       members_order: source
 
-::: pygaeb.models.quantity.Catalog
-    options:
-      show_root_heading: true
-      members_order: source
-
-::: pygaeb.models.quantity.CtlgAssign
-    options:
-      show_root_heading: true
-      members_order: source
-
 ::: pygaeb.models.quantity.PrjInfoQD
+    options:
+      show_root_heading: true
+      members_order: source
+
+## Catalog System (shared)
+
+Used across all document kinds (procurement, trade, cost, quantity) for DIN 276 cost groups, BIM references, locality catalogs, and work category assignments.
+
+::: pygaeb.models.catalog.CtlgAssign
+    options:
+      show_root_heading: true
+      members_order: source
+
+::: pygaeb.models.catalog.Catalog
     options:
       show_root_heading: true
       members_order: source

--- a/pygaeb/__init__.py
+++ b/pygaeb/__init__.py
@@ -12,7 +12,7 @@ Quick start:
 
 from __future__ import annotations
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 from pygaeb.exceptions import (
     ClassificationBackendError,
@@ -96,8 +96,9 @@ def __getattr__(name: str) -> object:
         "CategoryElementRef": ("pygaeb.models.cost", "CategoryElementRef"),
         "ConsortiumMember": ("pygaeb.models.cost", "ConsortiumMember"),
         "ConsortiumMemberRef": ("pygaeb.models.cost", "ConsortiumMemberRef"),
-        # X52 cost approach
+        # X52 cost approach / markup
         "CostApproach": ("pygaeb.models.item", "CostApproach"),
+        "MarkupSubQty": ("pygaeb.models.item", "MarkupSubQty"),
         "CostType": ("pygaeb.models.boq", "CostType"),
         # Quantity determination models (X31)
         "QtyDetermination": ("pygaeb.models.quantity", "QtyDetermination"),
@@ -109,8 +110,8 @@ def __getattr__(name: str) -> object:
         "QDetermItem": ("pygaeb.models.quantity", "QDetermItem"),
         "QTakeoffRow": ("pygaeb.models.quantity", "QTakeoffRow"),
         "QtyAttachment": ("pygaeb.models.quantity", "QtyAttachment"),
-        "Catalog": ("pygaeb.models.quantity", "Catalog"),
-        "CtlgAssign": ("pygaeb.models.quantity", "CtlgAssign"),
+        "Catalog": ("pygaeb.models.catalog", "Catalog"),
+        "CtlgAssign": ("pygaeb.models.catalog", "CtlgAssign"),
         "PrjInfoQD": ("pygaeb.models.quantity", "PrjInfoQD"),
         # Enums (advanced)
         "BkdnType": ("pygaeb.models.enums", "BkdnType"),
@@ -185,6 +186,7 @@ __all__ = [
     "ItemType",
     "LLMClassifier",
     "Lot",
+    "MarkupSubQty",
     "OrderInfo",
     "OrderItem",
     "PlannerInfo",

--- a/pygaeb/models/boq.py
+++ b/pygaeb/models/boq.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from pygaeb.models.catalog import CtlgAssign
 from pygaeb.models.enums import BkdnType
 from pygaeb.models.item import Item
 
@@ -44,6 +45,7 @@ class BoQInfo(BaseModel):
     bkdn: list[BoQBkdn] = Field(default_factory=list)
     outline_complete: bool = False
     cost_types: list[CostType] = Field(default_factory=list)
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
 
 
 class BoQCtgy(BaseModel):
@@ -56,6 +58,7 @@ class BoQCtgy(BaseModel):
     items: list[Item] = Field(default_factory=list)
     subcategories: list[BoQCtgy] = Field(default_factory=list)
     lbl_tx: str | None = None
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
     source_element: Any = Field(default=None, exclude=True, repr=False)
 
     def iter_items(self) -> Iterator[Item]:

--- a/pygaeb/models/catalog.py
+++ b/pygaeb/models/catalog.py
@@ -1,0 +1,33 @@
+"""Shared catalog models used across all GAEB document kinds.
+
+``CtlgAssign`` and ``Catalog`` are defined in the common GAEB Lib schema
+(``tgCtlgAssign``, ``tgCtlg``) and appear in procurement, trade, cost,
+and quantity determination documents.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class CtlgAssign(BaseModel):
+    """Catalog assignment — links an item/category to a catalog entry.
+
+    Used at BoQ, category, item, and measurement-row levels across
+    all GAEB document kinds.
+    """
+
+    ctlg_id: str = ""
+    ctlg_code: str = ""
+    quantity: Decimal | None = None
+
+
+class Catalog(BaseModel):
+    """Catalog definition (DIN 276 cost groups, BIM, locality, work category, etc.)."""
+
+    ctlg_id: str = ""
+    ctlg_type: str = ""
+    ctlg_name: str = ""
+    assign_type: str = ""

--- a/pygaeb/models/cost.py
+++ b/pygaeb/models/cost.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from pygaeb.models.catalog import CtlgAssign
 from pygaeb.models.item import (
     ClassificationResult,
     ExtractionResult,
@@ -150,6 +151,7 @@ class CostElement(BaseModel):
     is_bill_element: bool = False
     properties: list[CostProperty] = Field(default_factory=list)
     ref_groups: list[RefGroup] = Field(default_factory=list)
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
     children: list[CostElement] = Field(default_factory=list)
 
     @property
@@ -195,6 +197,7 @@ class ECCtgy(BaseModel):
     body: ECBody | None = None
     totals_net: Decimal | None = None
     totals_gross: Decimal | None = None
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
     source_element: Any = Field(default=None, exclude=True, repr=False)
 
     def iter_cost_elements(self) -> Iterator[CostElement]:

--- a/pygaeb/models/item.py
+++ b/pygaeb/models/item.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from pygaeb.models.catalog import CtlgAssign
 from pygaeb.models.enums import ClassificationFlag, ItemType, ValidationSeverity
 
 
@@ -104,6 +105,13 @@ class ExtractionResult(BaseModel):
         return max(0.0, min(1.0, v))
 
 
+class MarkupSubQty(BaseModel):
+    """Reference to an item being marked up (X52 ``<MarkupSubQty>``)."""
+
+    ref_rno: str = ""
+    sub_qty: Decimal | None = None
+
+
 class CostApproach(BaseModel):
     """Per-item calculation approach (X52 Kalkulationsansätze)."""
 
@@ -150,6 +158,9 @@ class Item(BaseModel):
     cost_approaches: list[CostApproach] = Field(default_factory=list)
     up_components: list[Decimal] = Field(default_factory=list)
     discount_pct: Decimal | None = None
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
+    markup_type: str | None = None
+    markup_sub_qtys: list[MarkupSubQty] = Field(default_factory=list)
     source_element: Any = Field(default=None, exclude=True, repr=False)
     raw_data: dict[str, Any] | None = Field(default=None, exclude=True)
 

--- a/pygaeb/models/order.py
+++ b/pygaeb/models/order.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from pygaeb.models.catalog import CtlgAssign
 from pygaeb.models.item import (
     ClassificationResult,
     ExtractionResult,
@@ -61,6 +62,9 @@ class OrderItem(BaseModel):
     item_type_tag: str | None = None
     delivery_chara: str | None = None
     is_service: bool = False
+
+    # --- catalog assignments (BIM, DIN 276, etc.) ---
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
 
     # --- logistics ---
     delivery_date: datetime | None = None
@@ -115,6 +119,7 @@ class OrderInfo(BaseModel):
     delivery_date: datetime | None = None
     reference: str | None = None
     currency: str = "EUR"
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
 
 
 class SupplierInfo(BaseModel):
@@ -164,6 +169,7 @@ class TradeOrder(BaseModel):
     planner_info: PlannerInfo | None = None
     invoice_info: InvoiceInfo | None = None
     items: list[OrderItem] = Field(default_factory=list)
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
     source_element: Any = Field(default=None, exclude=True, repr=False)
 
     def iter_items(self) -> Iterator[OrderItem]:

--- a/pygaeb/models/quantity.py
+++ b/pygaeb/models/quantity.py
@@ -11,6 +11,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from pygaeb.models.boq import BoQBkdn
+from pygaeb.models.catalog import Catalog, CtlgAssign
 from pygaeb.models.order import Address
 
 
@@ -50,23 +51,6 @@ class QtyAttachment(BaseModel):
     def data_base64(self) -> str:
         """Return base64-encoded data string."""
         return base64.b64encode(self.data).decode("ascii") if self.data else ""
-
-
-class CtlgAssign(BaseModel):
-    """Catalog assignment — links an item/category to a catalog entry."""
-
-    ctlg_id: str = ""
-    ctlg_code: str = ""
-    quantity: Decimal | None = None
-
-
-class Catalog(BaseModel):
-    """Catalog definition (DIN 276 cost groups, BIM, locality, work category, etc.)."""
-
-    ctlg_id: str = ""
-    ctlg_type: str = ""
-    ctlg_name: str = ""
-    assign_type: str = ""
 
 
 class QTakeoffRow(BaseModel):

--- a/pygaeb/parser/xml_v3/base_v3_parser.py
+++ b/pygaeb/parser/xml_v3/base_v3_parser.py
@@ -15,12 +15,13 @@ from lxml import etree
 
 from pygaeb.detector.version_detector import ParseRoute
 from pygaeb.models.boq import BoQ, BoQBkdn, BoQBody, BoQCtgy, BoQInfo, CostType, Lot
+from pygaeb.models.catalog import CtlgAssign
 from pygaeb.models.document import AwardInfo, GAEBDocument, GAEBInfo
 from pygaeb.models.enums import (
     BkdnType,
     ItemType,
 )
-from pygaeb.models.item import CostApproach, Item, QtySplit
+from pygaeb.models.item import CostApproach, Item, MarkupSubQty, QtySplit
 from pygaeb.parser.recovery import parse_xml_safe
 from pygaeb.parser.xml_v3.richtext_parser import parse_plaintext, parse_richtext
 
@@ -196,6 +197,8 @@ class BaseV3Parser:
             )
             info.cost_types.append(ct)
 
+        info.ctlg_assigns = self._parse_ctlg_assigns(info_el)
+
         return info
 
     def _parse_bkdn_v33(self, bkdn_el: etree._Element, info: BoQInfo) -> None:
@@ -279,6 +282,9 @@ class BaseV3Parser:
             for it_el in self._findall(item_el, "Item"):
                 item = self._parse_item(it_el, doc, current_path, lot_label)
                 ctgy.items.append(item)
+            for mu_el in self._findall(item_el, "MarkupItem"):
+                markup_item = self._parse_markup_item(mu_el, doc, current_path, lot_label)
+                ctgy.items.append(markup_item)
 
         for it_el in self._findall(target, "Item"):
             if it_el.getparent() is not None:
@@ -287,6 +293,8 @@ class BaseV3Parser:
                     continue
             item = self._parse_item(it_el, doc, current_path, lot_label)
             ctgy.items.append(item)
+
+        ctgy.ctlg_assigns = self._parse_ctlg_assigns(ctgy_el)
 
         if self._keep_xml:
             ctgy.source_element = ctgy_el
@@ -374,8 +382,53 @@ class BaseV3Parser:
         if disc_str:
             item.discount_pct = _parse_decimal(disc_str)
 
+        item.ctlg_assigns = self._parse_ctlg_assigns(item_el)
+
         if self._keep_xml:
             item.source_element = item_el
+
+        return item
+
+    def _parse_markup_item(
+        self,
+        el: etree._Element,
+        doc: GAEBDocument,
+        hierarchy_path: list[str],
+        lot_label: str = "",
+    ) -> Item:
+        """Parse a ``<MarkupItem>`` element (X52) into an ``Item`` with ``ItemType.MARKUP``."""
+        oz = el.get("RNoPart", "")
+        item = Item(
+            oz=oz,
+            hierarchy_path=hierarchy_path,
+            lot_label=lot_label or None,
+            item_type=ItemType.MARKUP,
+        )
+
+        item.short_text = self._text(el, "ShortText") or ""
+        item.markup_type = self._text(el, "MarkupType")
+
+        it_str = self._text(el, "ITMarkup")
+        if it_str:
+            item.total_price = _parse_decimal(it_str)
+
+        markup_str = self._text(el, "Markup")
+        if markup_str:
+            item.unit_price = _parse_decimal(markup_str)
+
+        disc_str = self._text(el, "DiscountPcnt")
+        if disc_str:
+            item.discount_pct = _parse_decimal(disc_str)
+
+        for sub_el in self._findall(el, "MarkupSubQty"):
+            ref_rno = self._text(sub_el, "RefRNoPart") or sub_el.get("RNoPart", "")
+            sub_qty = _parse_decimal(self._text(sub_el, "SubQty"))
+            item.markup_sub_qtys.append(MarkupSubQty(ref_rno=ref_rno, sub_qty=sub_qty))
+
+        item.ctlg_assigns = self._parse_ctlg_assigns(el)
+
+        if self._keep_xml:
+            item.source_element = el
 
         return item
 
@@ -454,6 +507,18 @@ class BaseV3Parser:
             found = self._findall(child, target_tag)
             results.extend(found)
         return results
+
+    def _parse_ctlg_assign(self, el: etree._Element) -> CtlgAssign:
+        """Parse a single ``<CtlgAssign>`` element."""
+        return CtlgAssign(
+            ctlg_id=self._text(el, "CtlgID") or "",
+            ctlg_code=self._text(el, "CtlgCode") or "",
+            quantity=_parse_decimal(self._text(el, "Quantity")),
+        )
+
+    def _parse_ctlg_assigns(self, parent: etree._Element) -> list[CtlgAssign]:
+        """Parse all ``<CtlgAssign>`` children of *parent*."""
+        return [self._parse_ctlg_assign(el) for el in self._findall(parent, "CtlgAssign")]
 
     def _has_lot_bkdn(self) -> bool:
         return any(b.bkdn_type == BkdnType.LOT for b in self._bkdn)

--- a/pygaeb/parser/xml_v3/cost_parser.py
+++ b/pygaeb/parser/xml_v3/cost_parser.py
@@ -204,6 +204,8 @@ class CostParser(BaseV3Parser):
             if gross:
                 ctgy.totals_gross = _parse_decimal(gross)
 
+        ctgy.ctlg_assigns = self._parse_ctlg_assigns(el)
+
         if self._keep_xml:
             ctgy.source_element = el
 
@@ -276,6 +278,8 @@ class CostParser(BaseV3Parser):
 
         for child_el in self._findall(el, "CostElement"):
             ce.children.append(self._parse_cost_element(child_el, doc))
+
+        ce.ctlg_assigns = self._parse_ctlg_assigns(el)
 
         if self._keep_xml:
             ce.source_element = el

--- a/pygaeb/parser/xml_v3/qty_parser.py
+++ b/pygaeb/parser/xml_v3/qty_parser.py
@@ -16,12 +16,11 @@ from pathlib import Path
 from lxml import etree
 
 from pygaeb.models.boq import BoQBkdn
+from pygaeb.models.catalog import Catalog, CtlgAssign
 from pygaeb.models.document import GAEBDocument
 from pygaeb.models.enums import BkdnType
 from pygaeb.models.order import Address
 from pygaeb.models.quantity import (
-    Catalog,
-    CtlgAssign,
     PrjInfoQD,
     QDetermItem,
     QTakeoffRow,

--- a/pygaeb/parser/xml_v3/trade_parser.py
+++ b/pygaeb/parser/xml_v3/trade_parser.py
@@ -116,6 +116,8 @@ class TradeParser(BaseV3Parser):
             item = self._parse_order_item(item_el, doc)
             order.items.append(item)
 
+        order.ctlg_assigns = self._parse_ctlg_assigns(order_el)
+
         if self._keep_xml:
             order.source_element = order_el
 
@@ -148,6 +150,8 @@ class TradeParser(BaseV3Parser):
         del_str = self._text(el, "DeliveryDate")
         if del_str:
             info.delivery_date = _parse_date(del_str)
+
+        info.ctlg_assigns = self._parse_ctlg_assigns(el)
 
         return info
 
@@ -235,6 +239,8 @@ class TradeParser(BaseV3Parser):
             item.delivery_date = _parse_date(dd)
 
         item.mode_of_shipment = self._text(item_el, "ModeOfShipment")
+
+        item.ctlg_assigns = self._parse_ctlg_assigns(item_el)
 
         if self._keep_xml:
             item.source_element = item_el

--- a/pygaeb/writer/gaeb_writer.py
+++ b/pygaeb/writer/gaeb_writer.py
@@ -13,6 +13,7 @@ from typing import Any
 from lxml import etree
 
 from pygaeb.models.boq import BoQ, BoQBody, BoQCtgy, BoQInfo
+from pygaeb.models.catalog import Catalog, CtlgAssign
 from pygaeb.models.cost import (
     CategoryElement,
     CostElement,
@@ -25,12 +26,10 @@ from pygaeb.models.cost import (
     RefGroup,
 )
 from pygaeb.models.document import AwardInfo, GAEBDocument, GAEBInfo
-from pygaeb.models.enums import BkdnType, ExchangePhase, SourceVersion
+from pygaeb.models.enums import BkdnType, ExchangePhase, ItemType, SourceVersion
 from pygaeb.models.item import CostApproach, Item
 from pygaeb.models.order import OrderItem, TradeOrder
 from pygaeb.models.quantity import (
-    Catalog,
-    CtlgAssign,
     QDetermItem,
     QtyAttachment,
     QtyBoQ,
@@ -45,6 +44,7 @@ from pygaeb.writer.version_registry import (
     WRITABLE_VERSIONS,
     VersionMeta,
     cost_namespace,
+    procurement_namespace,
     qty_namespace,
     trade_namespace,
 )
@@ -180,9 +180,10 @@ def _build_xml(
         _add_order(root, doc.order, phase, warnings)
         return root, warnings
 
-    ns_map = {None: meta.namespace}
+    ns = procurement_namespace(phase, SourceVersion(meta.version_tag))
+    ns_map = {None: ns}
     root = etree.Element("GAEB", nsmap=ns_map)  # type: ignore[arg-type]
-    root.set("xmlns", meta.namespace)
+    root.set("xmlns", ns)
 
     _add_gaeb_info(root, doc.gaeb_info, meta)
     _add_award(root, doc.award, phase, meta, warnings)
@@ -260,6 +261,9 @@ def _add_boq_info(parent: etree._Element, info: BoQInfo) -> None:
 
     _add_boq_info_cost_types(info_el, info)
 
+    for ca in info.ctlg_assigns:
+        _add_ctlg_assign(info_el, ca)
+
 
 def _add_body_categories(
     parent: etree._Element, body: BoQBody, phase: ExchangePhase,
@@ -279,6 +283,9 @@ def _add_ctgy(
     if ctgy.label:
         _add_text_el(ctgy_el, "LblTx", ctgy.label)
 
+    for ca in ctgy.ctlg_assigns:
+        _add_ctlg_assign(ctgy_el, ca)
+
     for sub in ctgy.subcategories:
         sub_body = etree.SubElement(ctgy_el, "BoQBody")
         _add_ctgy(sub_body, sub, phase, meta, warnings)
@@ -286,7 +293,10 @@ def _add_ctgy(
     if ctgy.items:
         itemlist = etree.SubElement(ctgy_el, "Itemlist")
         for item in ctgy.items:
-            _add_item(itemlist, item, phase, meta, warnings)
+            if item.item_type == ItemType.MARKUP:
+                _add_markup_item(itemlist, item)
+            else:
+                _add_item(itemlist, item, phase, meta, warnings)
 
 
 def _add_item(
@@ -357,6 +367,40 @@ def _add_item(
     if item.discount_pct is not None:
         _add_text_el(item_el, "DiscountPcnt", _fmt_decimal(item.discount_pct))
 
+    for ctlg in item.ctlg_assigns:
+        _add_ctlg_assign(item_el, ctlg)
+
+
+def _add_markup_item(parent: etree._Element, item: Item) -> None:
+    """Serialize a markup item as ``<MarkupItem>`` (X52)."""
+    mu_el = etree.SubElement(parent, "MarkupItem")
+    mu_el.set("RNoPart", item.oz)
+
+    if item.short_text:
+        _add_text_el(mu_el, "ShortText", item.short_text)
+
+    if item.markup_type:
+        _add_text_el(mu_el, "MarkupType", item.markup_type)
+
+    if item.unit_price is not None:
+        _add_text_el(mu_el, "Markup", _fmt_decimal(item.unit_price))
+
+    if item.total_price is not None:
+        _add_text_el(mu_el, "ITMarkup", _fmt_decimal(item.total_price))
+
+    if item.discount_pct is not None:
+        _add_text_el(mu_el, "DiscountPcnt", _fmt_decimal(item.discount_pct))
+
+    for sub in item.markup_sub_qtys:
+        sub_el = etree.SubElement(mu_el, "MarkupSubQty")
+        if sub.ref_rno:
+            _add_text_el(sub_el, "RefRNoPart", sub.ref_rno)
+        if sub.sub_qty is not None:
+            _add_text_el(sub_el, "SubQty", _fmt_decimal(sub.sub_qty))
+
+    for ca in item.ctlg_assigns:
+        _add_ctlg_assign(mu_el, ca)
+
 
 def _add_order(
     parent: etree._Element, order: TradeOrder,
@@ -377,6 +421,8 @@ def _add_order(
             _add_text_el(oi_el, "OrderDate", order.order_info.order_date.strftime("%Y-%m-%d"))
         if order.order_info.delivery_date:
             _add_text_el(oi_el, "DeliveryDate", order.order_info.delivery_date.strftime("%Y-%m-%d"))
+        for ctlg in order.order_info.ctlg_assigns:
+            _add_ctlg_assign(oi_el, ctlg)
 
     for info_name, tag_name in [
         ("supplier_info", "SupplierInfo"),
@@ -392,6 +438,9 @@ def _add_order(
 
     for item in order.items:
         _add_order_item(order_el, item, warnings)
+
+    for ctlg in order.ctlg_assigns:
+        _add_ctlg_assign(order_el, ctlg)
 
 
 def _add_address(parent: etree._Element, addr: Any) -> None:
@@ -456,6 +505,9 @@ def _add_order_item(
         _add_text_el(item_el, "ModeOfShipment", item.mode_of_shipment)
     if item.delivery_date:
         _add_text_el(item_el, "DeliveryDate", item.delivery_date.strftime("%Y-%m-%d"))
+
+    for ctlg in item.ctlg_assigns:
+        _add_ctlg_assign(item_el, ctlg)
 
 
 def _add_cost_approach(parent: etree._Element, ca: CostApproach) -> None:

--- a/pygaeb/writer/version_registry.py
+++ b/pygaeb/writer/version_registry.py
@@ -92,3 +92,18 @@ def qty_namespace(phase: ExchangePhase, version: SourceVersion) -> str:
     phase_num = phase.value.lstrip("X")
     ver = version.value
     return f"http://www.gaeb.de/GAEB_DA_XML/DA{phase_num}/{ver}"
+
+
+def procurement_namespace(phase: ExchangePhase, version: SourceVersion) -> str:
+    """Build the namespace URI for a procurement phase document (X80-X89).
+
+    For DA XML 3.0 and earlier the namespace is a fixed URI without phase.
+    For 3.1+ each phase has its own namespace (``DA83/3.3``, ``DA84/3.3``, etc.).
+    Falls back to ``DA86`` when the phase is not a known procurement phase.
+    """
+    meta = VERSION_REGISTRY.get(version)
+    if meta is not None and "200407" in meta.namespace:
+        return meta.namespace
+    phase_num = phase.value.lstrip("X") if phase.value.startswith("X") else "86"
+    ver = version.value
+    return f"http://www.gaeb.de/GAEB_DA_XML/DA{phase_num}/{ver}"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -59,7 +59,7 @@ class TestGAEBWriterTargetVersion:
         warnings = GAEBWriter.write(sample_document, output)
         content = output.read_text(encoding="utf-8")
         assert "3.3" in content
-        assert "DA86/3.3" in content
+        assert "DA83/3.3" in content
         assert len(warnings) == 0
 
     def test_write_v32(self, sample_document, tmp_path):
@@ -68,7 +68,7 @@ class TestGAEBWriterTargetVersion:
             sample_document, output, target_version=SourceVersion.DA_XML_32,
         )
         content = output.read_text(encoding="utf-8")
-        assert "DA86/3.2" in content
+        assert "DA83/3.2" in content
         assert "<Version>3.2</Version>" in content
         assert len(warnings) == 0
 
@@ -78,7 +78,7 @@ class TestGAEBWriterTargetVersion:
             sample_document, output, target_version=SourceVersion.DA_XML_31,
         )
         content = output.read_text(encoding="utf-8")
-        assert "DA86/3.1" in content
+        assert "DA83/3.1" in content
         assert "<Version>3.1</Version>" in content
 
     def test_write_v30(self, sample_document, tmp_path):
@@ -170,7 +170,7 @@ class TestGAEBWriterTargetVersion:
 
     def test_to_bytes_v33(self, sample_document):
         xml_bytes, warnings = GAEBWriter.to_bytes(sample_document)
-        assert b"DA86/3.3" in xml_bytes
+        assert b"DA83/3.3" in xml_bytes
         assert len(warnings) == 0
 
     def test_to_bytes_v20_german(self, sample_document):
@@ -261,7 +261,7 @@ class TestGAEBConverterFile:
 class TestGAEBConverterBytes:
     def test_convert_bytes_v33(self, sample_v33_file):
         xml_bytes, report = GAEBConverter.convert_bytes(sample_v33_file)
-        assert b"DA86/3.3" in xml_bytes
+        assert b"DA83/3.3" in xml_bytes
         assert report.items_converted == 3
 
     def test_convert_bytes_v20(self, sample_v33_file):
@@ -278,7 +278,7 @@ class TestGAEBConverterBytes:
             SAMPLE_V33_XML.encode("utf-8"),
             target_version=SourceVersion.DA_XML_32,
         )
-        assert b"DA86/3.2" in xml_bytes
+        assert b"DA83/3.2" in xml_bytes
         assert report.items_converted == 3
 
 

--- a/tests/test_findings_v141.py
+++ b/tests/test_findings_v141.py
@@ -1,0 +1,566 @@
+"""Tests for v1.4.1 schema-review findings fixes.
+
+Covers:
+  - Shared Catalog/CtlgAssign module
+  - CtlgAssign parsing/writing across procurement, cost, quantity, and trade
+  - Phase-specific procurement namespace
+  - MarkupItem parsing/writing (X52)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from textwrap import dedent
+
+from pygaeb import (
+    ExchangePhase,
+    GAEBParser,
+    GAEBWriter,
+    ItemType,
+    SourceVersion,
+)
+from pygaeb.models.catalog import Catalog, CtlgAssign
+
+# ---------------------------------------------------------------------------
+# XML fixtures
+# ---------------------------------------------------------------------------
+
+PROCUREMENT_WITH_CTLG = dedent("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA86/3.3">
+  <GAEBInfo><Version>3.3</Version></GAEBInfo>
+  <Award>
+    <AwardInfo>
+      <Prj>P1</Prj>
+      <Cur>EUR</Cur>
+    </AwardInfo>
+    <BoQ>
+      <BoQInfo>
+        <Name>TestBoQ</Name>
+        <BoQBkdn><BoQLevel Length="2"/></BoQBkdn>
+        <CtlgAssign>
+          <CtlgID>DIN276</CtlgID>
+          <CtlgCode>300</CtlgCode>
+        </CtlgAssign>
+      </BoQInfo>
+      <BoQBody>
+        <BoQCtgy RNoPart="01">
+          <LblTx>Section 1</LblTx>
+          <CtlgAssign>
+            <CtlgID>DIN276</CtlgID>
+            <CtlgCode>330</CtlgCode>
+          </CtlgAssign>
+          <Itemlist>
+            <Item RNoPart="0010">
+              <Qty>100</Qty>
+              <QU>m2</QU>
+              <UP>45.00</UP>
+              <IT>4500.00</IT>
+              <CtlgAssign>
+                <CtlgID>DIN276</CtlgID>
+                <CtlgCode>330.1</CtlgCode>
+                <Quantity>50</Quantity>
+              </CtlgAssign>
+            </Item>
+          </Itemlist>
+        </BoQCtgy>
+      </BoQBody>
+    </BoQ>
+  </Award>
+</GAEB>
+""")
+
+COST_WITH_CTLG = dedent("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA50/3.3">
+  <GAEBInfo><Version>3.3</Version></GAEBInfo>
+  <ElementalCosting>
+    <DP>50</DP>
+    <ECInfo><Name>Cost Test</Name></ECInfo>
+    <ECBody>
+      <ECCtgy>
+        <EleNo>100</EleNo>
+        <Descr>Foundation</Descr>
+        <CtlgAssign>
+          <CtlgID>DIN276</CtlgID>
+          <CtlgCode>300</CtlgCode>
+        </CtlgAssign>
+        <ECBody>
+          <CostElement>
+            <EleNo>100.1</EleNo>
+            <Descr>Concrete</Descr>
+            <Qty>50</Qty>
+            <QU>m3</QU>
+            <UP>120.00</UP>
+            <IT>6000.00</IT>
+            <CtlgAssign>
+              <CtlgID>DIN276</CtlgID>
+              <CtlgCode>331</CtlgCode>
+            </CtlgAssign>
+          </CostElement>
+        </ECBody>
+      </ECCtgy>
+    </ECBody>
+  </ElementalCosting>
+</GAEB>
+""")
+
+MARKUP_ITEM_XML = dedent("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA86/3.3">
+  <GAEBInfo><Version>3.3</Version></GAEBInfo>
+  <Award>
+    <AwardInfo><Cur>EUR</Cur></AwardInfo>
+    <BoQ>
+      <BoQInfo>
+        <Name>BoQ with Markup</Name>
+        <BoQBkdn><BoQLevel Length="2"/></BoQBkdn>
+      </BoQInfo>
+      <BoQBody>
+        <BoQCtgy RNoPart="01">
+          <LblTx>Section</LblTx>
+          <Itemlist>
+            <Item RNoPart="0010">
+              <Qty>10</Qty>
+              <QU>Stk</QU>
+              <UP>100.00</UP>
+              <IT>1000.00</IT>
+            </Item>
+            <Item RNoPart="0020">
+              <Qty>5</Qty>
+              <QU>m</QU>
+              <UP>50.00</UP>
+              <IT>250.00</IT>
+            </Item>
+            <MarkupItem RNoPart="9000">
+              <ShortText>Overhead</ShortText>
+              <MarkupType>ListInSubQty</MarkupType>
+              <Markup>10.50</Markup>
+              <ITMarkup>125.00</ITMarkup>
+              <DiscountPcnt>2.00</DiscountPcnt>
+              <MarkupSubQty>
+                <RefRNoPart>0010</RefRNoPart>
+                <SubQty>10</SubQty>
+              </MarkupSubQty>
+              <MarkupSubQty>
+                <RefRNoPart>0020</RefRNoPart>
+                <SubQty>5</SubQty>
+              </MarkupSubQty>
+            </MarkupItem>
+          </Itemlist>
+        </BoQCtgy>
+      </BoQBody>
+    </BoQ>
+  </Award>
+</GAEB>
+""")
+
+
+# ===================================================================
+# Shared Catalog module
+# ===================================================================
+
+
+class TestSharedCatalogModule:
+    def test_ctlg_assign_from_shared(self):
+        ca = CtlgAssign(ctlg_id="DIN276", ctlg_code="300", quantity=Decimal("1"))
+        assert ca.ctlg_id == "DIN276"
+        assert ca.quantity == Decimal("1")
+
+    def test_catalog_from_shared(self):
+        cat = Catalog(ctlg_id="C1", ctlg_type="DIN276", ctlg_name="Cost groups")
+        assert cat.ctlg_type == "DIN276"
+
+    def test_imports_from_top_level(self):
+        from pygaeb import Catalog as TopCat
+        from pygaeb import CtlgAssign as TopCA
+        assert TopCat is Catalog
+        assert TopCA is CtlgAssign
+
+    def test_quantity_reexports(self):
+        from pygaeb.models.quantity import Catalog as QtyCat
+        from pygaeb.models.quantity import CtlgAssign as QtyCA
+        assert QtyCat is Catalog
+        assert QtyCA is CtlgAssign
+
+
+# ===================================================================
+# CtlgAssign parsing — procurement
+# ===================================================================
+
+
+class TestCtlgAssignProcurement:
+    def test_parse_ctlg_on_boq_info(self, tmp_path):
+        f = tmp_path / "ctlg.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        info = doc.award.boq.boq_info
+        assert info is not None
+        assert len(info.ctlg_assigns) == 1
+        assert info.ctlg_assigns[0].ctlg_id == "DIN276"
+        assert info.ctlg_assigns[0].ctlg_code == "300"
+
+    def test_parse_ctlg_on_boq_ctgy(self, tmp_path):
+        f = tmp_path / "ctlg.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        ctgy = doc.award.boq.lots[0].body.categories[0]
+        assert len(ctgy.ctlg_assigns) == 1
+        assert ctgy.ctlg_assigns[0].ctlg_code == "330"
+
+    def test_parse_ctlg_on_item(self, tmp_path):
+        f = tmp_path / "ctlg.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        items = list(doc.award.boq.iter_items())
+        assert len(items) == 1
+        item = items[0]
+        assert len(item.ctlg_assigns) == 1
+        assert item.ctlg_assigns[0].ctlg_code == "330.1"
+        assert item.ctlg_assigns[0].quantity == Decimal("50")
+
+    def test_roundtrip_ctlg_procurement(self, tmp_path):
+        f = tmp_path / "ctlg.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+
+        xml_bytes, _ = GAEBWriter.to_bytes(doc)
+        assert b"<CtlgAssign>" in xml_bytes
+        assert b"<CtlgID>DIN276</CtlgID>" in xml_bytes
+        assert b"<CtlgCode>330.1</CtlgCode>" in xml_bytes
+
+        out = tmp_path / "out.X86"
+        out.write_bytes(xml_bytes)
+        doc2 = GAEBParser.parse(out)
+        item2 = next(iter(doc2.award.boq.iter_items()))
+        assert item2.ctlg_assigns[0].ctlg_code == "330.1"
+
+
+# ===================================================================
+# CtlgAssign parsing — cost
+# ===================================================================
+
+
+class TestCtlgAssignCost:
+    def test_parse_ctlg_on_ec_ctgy(self, tmp_path):
+        f = tmp_path / "cost.X50"
+        f.write_text(COST_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        ec = doc.elemental_costing
+        assert ec is not None
+        ctgy = ec.body.categories[0]
+        assert len(ctgy.ctlg_assigns) == 1
+        assert ctgy.ctlg_assigns[0].ctlg_code == "300"
+
+    def test_parse_ctlg_on_cost_element(self, tmp_path):
+        f = tmp_path / "cost.X50"
+        f.write_text(COST_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        ec = doc.elemental_costing
+        assert ec is not None
+        ce = next(iter(ec.iter_items()))
+        assert len(ce.ctlg_assigns) == 1
+        assert ce.ctlg_assigns[0].ctlg_code == "331"
+
+
+# ===================================================================
+# Phase-specific procurement namespace
+# ===================================================================
+
+
+class TestProcurementNamespace:
+    def test_x83_namespace(self, tmp_path):
+        f = tmp_path / "test.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        xml_bytes, _ = GAEBWriter.to_bytes(
+            doc, phase=ExchangePhase.X83,
+        )
+        assert b"DA83/3.3" in xml_bytes
+
+    def test_x84_namespace(self, tmp_path):
+        f = tmp_path / "test.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        xml_bytes, _ = GAEBWriter.to_bytes(
+            doc, phase=ExchangePhase.X84,
+        )
+        assert b"DA84/3.3" in xml_bytes
+
+    def test_x86_namespace(self, tmp_path):
+        f = tmp_path / "test.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        xml_bytes, _ = GAEBWriter.to_bytes(doc)
+        assert b"DA86/3.3" in xml_bytes
+
+    def test_v30_ignores_phase(self, tmp_path):
+        f = tmp_path / "test.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        xml_bytes, _ = GAEBWriter.to_bytes(
+            doc,
+            phase=ExchangePhase.X83,
+            target_version=SourceVersion.DA_XML_30,
+        )
+        assert b"200407" in xml_bytes
+
+    def test_v32_phase_specific(self, tmp_path):
+        f = tmp_path / "test.X86"
+        f.write_text(PROCUREMENT_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        xml_bytes, _ = GAEBWriter.to_bytes(
+            doc,
+            phase=ExchangePhase.X84,
+            target_version=SourceVersion.DA_XML_32,
+        )
+        assert b"DA84/3.2" in xml_bytes
+
+
+# ===================================================================
+# MarkupItem parsing and writing
+# ===================================================================
+
+
+class TestMarkupItem:
+    def test_parse_markup_item(self, tmp_path):
+        f = tmp_path / "markup.X86"
+        f.write_text(MARKUP_ITEM_XML, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        items = list(doc.award.boq.iter_items())
+        assert len(items) == 3
+
+        normal_items = [i for i in items if i.item_type != ItemType.MARKUP]
+        markup_items = [i for i in items if i.item_type == ItemType.MARKUP]
+        assert len(normal_items) == 2
+        assert len(markup_items) == 1
+
+        mu = markup_items[0]
+        assert mu.oz == "9000"
+        assert mu.short_text == "Overhead"
+        assert mu.markup_type == "ListInSubQty"
+        assert mu.unit_price == Decimal("10.50")
+        assert mu.total_price == Decimal("125.00")
+        assert mu.discount_pct == Decimal("2.00")
+
+    def test_parse_markup_sub_qtys(self, tmp_path):
+        f = tmp_path / "markup.X86"
+        f.write_text(MARKUP_ITEM_XML, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        items = list(doc.award.boq.iter_items())
+        mu = next(i for i in items if i.item_type == ItemType.MARKUP)
+
+        assert len(mu.markup_sub_qtys) == 2
+        assert mu.markup_sub_qtys[0].ref_rno == "0010"
+        assert mu.markup_sub_qtys[0].sub_qty == Decimal("10")
+        assert mu.markup_sub_qtys[1].ref_rno == "0020"
+        assert mu.markup_sub_qtys[1].sub_qty == Decimal("5")
+
+    def test_markup_roundtrip(self, tmp_path):
+        f = tmp_path / "markup.X86"
+        f.write_text(MARKUP_ITEM_XML, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+
+        xml_bytes, _ = GAEBWriter.to_bytes(doc)
+        assert b"<MarkupItem" in xml_bytes
+        assert b"<MarkupType>ListInSubQty</MarkupType>" in xml_bytes
+        assert b"<ITMarkup>" in xml_bytes
+        assert b"<RefRNoPart>0010</RefRNoPart>" in xml_bytes
+
+        out = tmp_path / "out.X86"
+        out.write_bytes(xml_bytes)
+        doc2 = GAEBParser.parse(out)
+        items2 = list(doc2.award.boq.iter_items())
+        mu2 = next(i for i in items2 if i.item_type == ItemType.MARKUP)
+        assert mu2.markup_type == "ListInSubQty"
+        assert len(mu2.markup_sub_qtys) == 2
+        assert mu2.total_price == Decimal("125.00")
+
+    def test_markup_item_type_flag(self, tmp_path):
+        f = tmp_path / "markup.X86"
+        f.write_text(MARKUP_ITEM_XML, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        items = list(doc.award.boq.iter_items())
+        mu = next(i for i in items if i.item_type == ItemType.MARKUP)
+        assert mu.item_type == ItemType.MARKUP
+        assert mu.item_type.affects_total is False
+
+
+# ===================================================================
+# MarkupSubQty model
+# ===================================================================
+
+
+class TestMarkupSubQtyModel:
+    def test_defaults(self):
+        from pygaeb.models.item import MarkupSubQty
+        m = MarkupSubQty()
+        assert m.ref_rno == ""
+        assert m.sub_qty is None
+
+    def test_with_values(self):
+        from pygaeb.models.item import MarkupSubQty
+        m = MarkupSubQty(ref_rno="0010", sub_qty=Decimal("42"))
+        assert m.ref_rno == "0010"
+        assert m.sub_qty == Decimal("42")
+
+
+# ===================================================================
+# Regression: existing tests still pass with new fields
+# ===================================================================
+
+
+class TestNoRegressionOnNewFields:
+    def test_item_ctlg_assigns_default_empty(self):
+        from pygaeb.models.item import Item
+        item = Item()
+        assert item.ctlg_assigns == []
+        assert item.markup_type is None
+        assert item.markup_sub_qtys == []
+
+    def test_boq_ctgy_ctlg_assigns_default_empty(self):
+        from pygaeb.models.boq import BoQCtgy
+        ctgy = BoQCtgy()
+        assert ctgy.ctlg_assigns == []
+
+    def test_boq_info_ctlg_assigns_default_empty(self):
+        from pygaeb.models.boq import BoQInfo
+        info = BoQInfo()
+        assert info.ctlg_assigns == []
+
+    def test_cost_element_ctlg_assigns_default_empty(self):
+        from pygaeb.models.cost import CostElement
+        ce = CostElement()
+        assert ce.ctlg_assigns == []
+
+    def test_ec_ctgy_ctlg_assigns_default_empty(self):
+        from pygaeb.models.cost import ECCtgy
+        ctgy = ECCtgy()
+        assert ctgy.ctlg_assigns == []
+
+    def test_order_item_ctlg_assigns_default_empty(self):
+        from pygaeb.models.order import OrderItem
+        oi = OrderItem()
+        assert oi.ctlg_assigns == []
+
+    def test_trade_order_ctlg_assigns_default_empty(self):
+        from pygaeb.models.order import TradeOrder
+        to = TradeOrder()
+        assert to.ctlg_assigns == []
+
+    def test_order_info_ctlg_assigns_default_empty(self):
+        from pygaeb.models.order import OrderInfo
+        oi = OrderInfo()
+        assert oi.ctlg_assigns == []
+
+
+# ===================================================================
+# CtlgAssign parsing — trade
+# ===================================================================
+
+TRADE_WITH_CTLG = dedent("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA93/3.3">
+  <GAEBInfo><Version>3.3</Version></GAEBInfo>
+  <Order>
+    <DP>93</DP>
+    <OrderInfo>
+      <OrderNo>ORD-001</OrderNo>
+      <Cur>EUR</Cur>
+      <CtlgAssign>
+        <CtlgID>BIM</CtlgID>
+        <CtlgCode>PRJ-BIM-001</CtlgCode>
+      </CtlgAssign>
+    </OrderInfo>
+    <SupplierInfo>
+      <Address><Name>Supplier GmbH</Name></Address>
+    </SupplierInfo>
+    <OrderItem>
+      <ArtNo>MAT-100</ArtNo>
+      <Qty>50</Qty>
+      <QU>Stk</QU>
+      <NetPrice>25.00</NetPrice>
+      <CtlgAssign>
+        <CtlgID>BIM</CtlgID>
+        <CtlgCode>ELEM-A1</CtlgCode>
+      </CtlgAssign>
+      <CtlgAssign>
+        <CtlgID>DIN276</CtlgID>
+        <CtlgCode>330</CtlgCode>
+      </CtlgAssign>
+    </OrderItem>
+    <OrderItem>
+      <ArtNo>MAT-200</ArtNo>
+      <Qty>10</Qty>
+      <QU>m</QU>
+      <NetPrice>12.50</NetPrice>
+    </OrderItem>
+    <CtlgAssign>
+      <CtlgID>DIN276</CtlgID>
+      <CtlgCode>300</CtlgCode>
+    </CtlgAssign>
+  </Order>
+</GAEB>
+""")
+
+
+class TestCtlgAssignTrade:
+    def test_parse_ctlg_on_order(self, tmp_path):
+        f = tmp_path / "trade.X93"
+        f.write_text(TRADE_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        assert doc.order is not None
+        assert len(doc.order.ctlg_assigns) == 1
+        assert doc.order.ctlg_assigns[0].ctlg_id == "DIN276"
+        assert doc.order.ctlg_assigns[0].ctlg_code == "300"
+
+    def test_parse_ctlg_on_order_info(self, tmp_path):
+        f = tmp_path / "trade.X93"
+        f.write_text(TRADE_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        assert doc.order is not None
+        assert doc.order.order_info is not None
+        assert len(doc.order.order_info.ctlg_assigns) == 1
+        assert doc.order.order_info.ctlg_assigns[0].ctlg_id == "BIM"
+
+    def test_parse_ctlg_on_order_item(self, tmp_path):
+        f = tmp_path / "trade.X93"
+        f.write_text(TRADE_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+        assert doc.order is not None
+        items = list(doc.order.iter_items())
+        assert len(items) == 2
+        assert len(items[0].ctlg_assigns) == 2
+        assert items[0].ctlg_assigns[0].ctlg_id == "BIM"
+        assert items[0].ctlg_assigns[0].ctlg_code == "ELEM-A1"
+        assert items[0].ctlg_assigns[1].ctlg_id == "DIN276"
+        assert len(items[1].ctlg_assigns) == 0
+
+    def test_roundtrip_ctlg_trade(self, tmp_path):
+        f = tmp_path / "trade.X93"
+        f.write_text(TRADE_WITH_CTLG, encoding="utf-8")
+        doc = GAEBParser.parse(f)
+
+        xml_bytes, _ = GAEBWriter.to_bytes(
+            doc, phase=ExchangePhase.X93,
+        )
+        assert b"<CtlgAssign>" in xml_bytes
+        assert b"<CtlgID>BIM</CtlgID>" in xml_bytes
+        assert b"<CtlgCode>ELEM-A1</CtlgCode>" in xml_bytes
+        assert b"<CtlgCode>300</CtlgCode>" in xml_bytes
+
+        out = tmp_path / "out.X93"
+        out.write_bytes(xml_bytes)
+        doc2 = GAEBParser.parse(out)
+        assert doc2.order is not None
+
+        assert len(doc2.order.ctlg_assigns) == 1
+        assert doc2.order.ctlg_assigns[0].ctlg_code == "300"
+
+        assert doc2.order.order_info is not None
+        assert len(doc2.order.order_info.ctlg_assigns) == 1
+        assert doc2.order.order_info.ctlg_assigns[0].ctlg_id == "BIM"
+
+        items2 = list(doc2.order.iter_items())
+        assert len(items2[0].ctlg_assigns) == 2
+        assert items2[0].ctlg_assigns[0].ctlg_code == "ELEM-A1"


### PR DESCRIPTION
- Move CtlgAssign and Catalog to shared pygaeb/models/catalog.py for cross-package reuse (was tied to quantity.py)
- Add CtlgAssign parsing and writing across all four document kinds: procurement (Item, BoQCtgy, BoQInfo), cost (CostElement, ECCtgy), trade (TradeOrder, OrderInfo, OrderItem), and quantity (unchanged)
- Fix procurement writer namespace: use phase-specific DA{phase}/{ver} (e.g. DA83/3.3 for X83) instead of hardcoded DA86; fall back to fixed 200407 URI for DA XML 3.0 and earlier
- Add MarkupItem support for X52: parse <MarkupItem> as Item with ItemType.MARKUP, new MarkupSubQty model, round-trip writer support
- 33 new tests, 455 total passing