### PR TITLE
feat: procurement totals, VAT, PrjInfo & item attachments (v1.5.0)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,22 @@ All notable changes to pyGAEB are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-03-15
+
+### Added
+
+- **Procurement Totals + VAT** — `Totals` and `VATPart` models for authoritative financial summaries from `<Totals>` elements
+- `totals` field on `BoQInfo`, `BoQCtgy`, and `Lot` — parsed from and written back to XML
+- Full `<Totals>` schema coverage: `Total`, `DiscountPcnt`/`DiscountAmt`/`TotAfterDisc`, `TotalLSUM`, `VAT`, `TotalNet`, `TotalNetUpComp` (UpComp1–6), `VATPart` (multiple VAT rates with per-rate breakdown), `VATAmount`, `TotalGross`
+- **Item-level VAT** — `vat` field on `Item` for per-item VAT rate percentage
+- **Complete PrjInfo** — `AwardInfo` now exposes all `<PrjInfo>` fields: `prj_id`, `lbl_prj`, `description`, `currency_label`, `bid_comm_perm`, `alter_bid_perm`, `up_frac_dig`, `ctlg_assigns`
+- `<PrjInfo>` serialization in writer — round-trips project metadata correctly
+- `UPFracDig` (unit price decimal places) — parsed and exposed on `AwardInfo.up_frac_dig`
+- **Procurement Item Attachments** — URI references (`<attachment>`) and embedded base64 images (`<image>`) from `<DetailTxt>` are now parsed into `Item.attachments`
+- `DocumentAPI.summary()` now includes `total_net`, `total_gross`, `vat_rate`, `vat_amount`, and `up_frac_dig` for procurement documents
+- `Totals` and `VATPart` exported from top-level `pygaeb` module
+- 40 new tests for totals parsing/writing, VATPart, item VAT, PrjInfo, and attachments
+
 ## [1.4.1] - 2026-03-15
 
 ### Added
@@ -130,6 +146,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `py.typed` marker for PEP 561 compliance
 - Comprehensive test suite (193 tests)
 
+[1.5.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.5.0
 [1.4.1]: https://github.com/frameiq/pygaeb/releases/tag/v1.4.1
 [1.4.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.4.0
 [1.3.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.3.0

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -54,6 +54,49 @@ Look up a specific item by its OZ (ordinal number):
 item = doc.award.boq.get_item("01.02.0030")
 ```
 
+## Financial Summaries & Project Info
+
+Procurement documents (X84 bids, X86 awards, X89 invoices) carry authoritative totals, VAT breakdowns, and discount data at the BoQ and category level:
+
+```python
+# BoQ-level totals (from the <Totals> element, not recomputed)
+totals = doc.award.boq.boq_info.totals
+if totals:
+    print(totals.total_net)      # Decimal("95000.00")
+    print(totals.total_gross)    # Decimal("113050.00")
+    print(totals.vat)            # Decimal("19.00")  — VAT rate %
+    print(totals.vat_amount)     # Decimal("18050.00")
+    print(totals.discount_pcnt)  # Decimal("5.000000") or None
+
+    # Multiple VAT rates (e.g., 19% + 7%)
+    for vp in totals.vat_parts:
+        print(f"{vp.vat_pcnt}%: net={vp.total_net_part}, vat={vp.vat_amount}")
+
+# Category-level subtotals
+for lot in doc.award.boq.lots:
+    for ctgy in lot.body.categories:
+        if ctgy.totals:
+            print(f"{ctgy.label}: net={ctgy.totals.total_net}")
+
+# Item-level VAT
+for item in doc.award.boq.iter_items():
+    if item.vat is not None:
+        print(f"{item.oz}: VAT {item.vat}%")
+```
+
+Project metadata from `<PrjInfo>` is merged into `AwardInfo`:
+
+```python
+print(doc.award.project_name)     # "Neubau Schule"
+print(doc.award.prj_id)           # project GUID
+print(doc.award.lbl_prj)          # project label
+print(doc.award.description)      # project description
+print(doc.award.currency_label)   # "Euro"
+print(doc.award.up_frac_dig)      # 2 or 3 — unit price decimal places
+print(doc.award.bid_comm_perm)    # True/False
+print(doc.award.alter_bid_perm)   # True/False
+```
+
 ## Document Navigation
 
 For advanced querying, use `DocumentAPI`:

--- a/docs/guides/parsing.md
+++ b/docs/guides/parsing.md
@@ -170,6 +170,41 @@ doc.award                # AwardInfo (project info + BoQ)
 doc.award.boq            # BoQ (lots > categories > items)
 ```
 
+**Project metadata** from `<PrjInfo>` is merged into `AwardInfo`:
+
+```python
+doc.award.project_name   # str — project name
+doc.award.prj_id         # str — project GUID
+doc.award.lbl_prj        # str — project label
+doc.award.description    # str — project description
+doc.award.currency_label # str — e.g., "Euro"
+doc.award.up_frac_dig    # int (2 or 3) — unit price decimal places
+doc.award.bid_comm_perm  # bool — bidder comments permitted
+doc.award.alter_bid_perm # bool — alternative bids permitted
+```
+
+**Financial summaries** are parsed from `<Totals>` elements on BoQInfo, categories, and lots. These carry the authoritative net/gross totals, VAT rates, VAT breakdowns, and discount data — present in X84 (bid), X86 (award), and X89 (invoice) files:
+
+```python
+totals = doc.award.boq.boq_info.totals
+if totals:
+    totals.total           # Decimal — sum before discounts
+    totals.total_net       # Decimal — net after discounts
+    totals.total_gross     # Decimal — gross (net + VAT)
+    totals.vat             # Decimal — VAT rate %
+    totals.vat_amount      # Decimal — total VAT amount
+    totals.discount_pcnt   # Decimal — discount percentage
+    totals.vat_parts       # list[VATPart] — per-rate breakdown
+```
+
+**Item-level VAT** — each item can carry its own VAT rate:
+
+```python
+for item in doc.award.boq.iter_items():
+    if item.vat is not None:
+        print(f"{item.oz}: {item.vat}%")
+```
+
 ### Trade documents (X93–X97)
 
 ```python

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -56,6 +56,20 @@ The unified domain model that all parser tracks produce. Documents are **procure
       show_root_heading: true
       members_order: source
 
+## Totals & VAT
+
+Financial summary data from `<Totals>` elements on BoQInfo, BoQCtgy, and Lot. Includes discount breakdowns, per-rate VAT partitions, and net/gross totals.
+
+::: pygaeb.models.boq.Totals
+    options:
+      show_root_heading: true
+      members_order: source
+
+::: pygaeb.models.boq.VATPart
+    options:
+      show_root_heading: true
+      members_order: source
+
 ## Item (Procurement)
 
 ::: pygaeb.models.item.Item

--- a/pygaeb/__init__.py
+++ b/pygaeb/__init__.py
@@ -12,7 +12,7 @@ Quick start:
 
 from __future__ import annotations
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 from pygaeb.exceptions import (
     ClassificationBackendError,
@@ -68,6 +68,8 @@ def __getattr__(name: str) -> object:
         "BoQCtgy": ("pygaeb.models.boq", "BoQCtgy"),
         "BoQInfo": ("pygaeb.models.boq", "BoQInfo"),
         "Lot": ("pygaeb.models.boq", "Lot"),
+        "Totals": ("pygaeb.models.boq", "Totals"),
+        "VATPart": ("pygaeb.models.boq", "VATPart"),
         # Trade models
         "TradeOrder": ("pygaeb.models.order", "TradeOrder"),
         "OrderItem": ("pygaeb.models.order", "OrderItem"),
@@ -209,7 +211,9 @@ __all__ = [
     "SourceVersion",
     "StructuredExtractor",
     "SupplierInfo",
+    "Totals",
     "TradeOrder",
+    "VATPart",
     "ValidationMode",
     "ValidationResult",
     "ValidationSeverity",

--- a/pygaeb/api/document_api.py
+++ b/pygaeb/api/document_api.py
@@ -279,6 +279,15 @@ class DocumentAPI:
         elif self._doc.is_procurement:
             result["lots"] = len(self.lots)
             result["is_multi_lot"] = self.is_multi_lot
+            boq_info = self._doc.award.boq.boq_info
+            if boq_info and boq_info.totals:
+                t = boq_info.totals
+                result["total_net"] = str(t.total_net) if t.total_net else None
+                result["total_gross"] = str(t.total_gross) if t.total_gross else None
+                result["vat_rate"] = str(t.vat) if t.vat else None
+                result["vat_amount"] = str(t.vat_amount) if t.vat_amount else None
+            if self._doc.award.up_frac_dig is not None:
+                result["up_frac_dig"] = self._doc.award.up_frac_dig
         else:
             result["has_supplier_info"] = (
                 self._doc.order is not None

--- a/pygaeb/models/boq.py
+++ b/pygaeb/models/boq.py
@@ -37,6 +37,39 @@ class CostType(BaseModel):
     label: str = ""
 
 
+class VATPart(BaseModel):
+    """A single VAT rate partition within a ``Totals`` block.
+
+    GAEB files can have multiple VAT rates (e.g. 19% and 7%) applied to
+    different subsets of items.  Each ``VATPart`` carries the net amount
+    subject to that rate and the resulting VAT amount.
+    """
+
+    vat_pcnt: Decimal = Decimal("0")
+    total_net_part: Decimal | None = None
+    vat_amount: Decimal | None = None
+
+
+class Totals(BaseModel):
+    """Authoritative financial summary (``<Totals>``) on BoQInfo, BoQCtgy, or Lot.
+
+    Fields mirror the ``tgTotals`` schema type.  All monetary values use
+    ``Decimal`` for precision.
+    """
+
+    total: Decimal | None = None
+    discount_pcnt: Decimal | None = None
+    discount_amt: Decimal | None = None
+    tot_after_disc: Decimal | None = None
+    total_lsum: Decimal | None = None
+    vat: Decimal | None = None
+    total_net: Decimal | None = None
+    total_net_up_comp: list[Decimal] = Field(default_factory=list)
+    vat_parts: list[VATPart] = Field(default_factory=list)
+    vat_amount: Decimal | None = None
+    total_gross: Decimal | None = None
+
+
 class BoQInfo(BaseModel):
     """BoQ-level metadata including breakdown definitions."""
 
@@ -46,6 +79,7 @@ class BoQInfo(BaseModel):
     outline_complete: bool = False
     cost_types: list[CostType] = Field(default_factory=list)
     ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
+    totals: Totals | None = None
 
 
 class BoQCtgy(BaseModel):
@@ -59,6 +93,7 @@ class BoQCtgy(BaseModel):
     subcategories: list[BoQCtgy] = Field(default_factory=list)
     lbl_tx: str | None = None
     ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
+    totals: Totals | None = None
     source_element: Any = Field(default=None, exclude=True, repr=False)
 
     def iter_items(self) -> Iterator[Item]:
@@ -89,6 +124,7 @@ class Lot(BaseModel):
     label: str = ""
     boq_info: BoQInfo | None = None
     body: BoQBody = Field(default_factory=BoQBody)
+    totals: Totals | None = None
 
     def __repr__(self) -> str:
         count = sum(1 for _ in self.iter_items())

--- a/pygaeb/models/document.py
+++ b/pygaeb/models/document.py
@@ -10,6 +10,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from pygaeb.models.boq import BoQ
+from pygaeb.models.catalog import CtlgAssign
 from pygaeb.models.cost import ElementalCosting
 from pygaeb.models.enums import (
     DocumentKind,
@@ -35,7 +36,11 @@ class GAEBInfo(BaseModel):
 
 
 class AwardInfo(BaseModel):
-    """Project-level award information (procurement phases X80-X89)."""
+    """Project-level award information (procurement phases X80-X89).
+
+    Fields from both ``<AwardInfo>`` and ``<PrjInfo>`` are merged here
+    to give a single, developer-friendly project metadata object.
+    """
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -47,6 +52,17 @@ class AwardInfo(BaseModel):
     procurement_type: str | None = None
     date: datetime | None = None
     place: str | None = None
+
+    # --- PrjInfo fields ---
+    prj_id: str | None = None
+    lbl_prj: str | None = None
+    description: str | None = None
+    currency_label: str | None = None
+    bid_comm_perm: bool = False
+    alter_bid_perm: bool = False
+    up_frac_dig: int | None = None
+    ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
+
     boq: BoQ = Field(default_factory=BoQ)
     source_element: Any = Field(default=None, exclude=True, repr=False)
 

--- a/pygaeb/models/item.py
+++ b/pygaeb/models/item.py
@@ -158,6 +158,7 @@ class Item(BaseModel):
     cost_approaches: list[CostApproach] = Field(default_factory=list)
     up_components: list[Decimal] = Field(default_factory=list)
     discount_pct: Decimal | None = None
+    vat: Decimal | None = None
     ctlg_assigns: list[CtlgAssign] = Field(default_factory=list)
     markup_type: str | None = None
     markup_sub_qtys: list[MarkupSubQty] = Field(default_factory=list)

--- a/pygaeb/parser/xml_v3/base_v3_parser.py
+++ b/pygaeb/parser/xml_v3/base_v3_parser.py
@@ -5,6 +5,7 @@ Supports iterparse for large files and two-pass recovery on malformed XML.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
@@ -14,14 +15,24 @@ from typing import Any
 from lxml import etree
 
 from pygaeb.detector.version_detector import ParseRoute
-from pygaeb.models.boq import BoQ, BoQBkdn, BoQBody, BoQCtgy, BoQInfo, CostType, Lot
+from pygaeb.models.boq import (
+    BoQ,
+    BoQBkdn,
+    BoQBody,
+    BoQCtgy,
+    BoQInfo,
+    CostType,
+    Lot,
+    Totals,
+    VATPart,
+)
 from pygaeb.models.catalog import CtlgAssign
 from pygaeb.models.document import AwardInfo, GAEBDocument, GAEBInfo
 from pygaeb.models.enums import (
     BkdnType,
     ItemType,
 )
-from pygaeb.models.item import CostApproach, Item, MarkupSubQty, QtySplit
+from pygaeb.models.item import Attachment, CostApproach, Item, MarkupSubQty, QtySplit
 from pygaeb.parser.recovery import parse_xml_safe
 from pygaeb.parser.xml_v3.richtext_parser import parse_plaintext, parse_richtext
 
@@ -142,6 +153,26 @@ class BaseV3Parser:
             if not award.currency or award.currency == "EUR":
                 award.currency = self._text(prj_info_el, "Cur") or award.currency
 
+            award.prj_id = self._text(prj_info_el, "PrjID")
+            award.lbl_prj = self._text(prj_info_el, "LblPrj")
+            award.description = self._text(prj_info_el, "Descrip")
+            award.currency_label = self._text(prj_info_el, "CurLbl")
+
+            bcp = self._text(prj_info_el, "BidCommPerm")
+            if bcp and bcp.lower() in ("yes", "true", "1"):
+                award.bid_comm_perm = True
+
+            abp = self._text(prj_info_el, "AlterBidPerm")
+            if abp and abp.lower() in ("yes", "true", "1"):
+                award.alter_bid_perm = True
+
+            upfd = self._text(prj_info_el, "UPFracDig")
+            if upfd:
+                with contextlib.suppress(ValueError):
+                    award.up_frac_dig = int(upfd)
+
+            award.ctlg_assigns = self._parse_ctlg_assigns(prj_info_el)
+
         boq_el = self._find(award_el, "BoQ")
         if boq_el is not None:
             award.boq = self._parse_boq(boq_el, doc)
@@ -165,6 +196,7 @@ class BaseV3Parser:
         if boq_body_el is not None:
             lot = Lot(rno="1", label="Default", boq_info=boq.boq_info)
             lot.body = self._parse_boq_body(boq_body_el, doc)
+            lot.totals = self._parse_totals(boq_body_el)
             boq.lots.append(lot)
 
             lot_els = self._findall(boq_body_el, "BoQCtgy")
@@ -175,6 +207,7 @@ class BaseV3Parser:
                     label = self._text(lot_el, "LblTx") or f"Lot {i + 1}"
                     lot = Lot(rno=rno, label=label, boq_info=boq.boq_info)
                     lot.body = self._parse_ctgy_as_body(lot_el, doc, lot_label=label)
+                    lot.totals = self._parse_totals(lot_el)
                     boq.lots.append(lot)
 
         return boq
@@ -198,6 +231,7 @@ class BaseV3Parser:
             info.cost_types.append(ct)
 
         info.ctlg_assigns = self._parse_ctlg_assigns(info_el)
+        info.totals = self._parse_totals(info_el)
 
         return info
 
@@ -295,6 +329,7 @@ class BaseV3Parser:
             ctgy.items.append(item)
 
         ctgy.ctlg_assigns = self._parse_ctlg_assigns(ctgy_el)
+        ctgy.totals = self._parse_totals(ctgy_el)
 
         if self._keep_xml:
             ctgy.source_element = ctgy_el
@@ -353,6 +388,8 @@ class BaseV3Parser:
             if lt_str:
                 item.long_text = parse_plaintext(lt_str)
 
+        item.attachments = self._parse_item_attachments(item_el)
+
         bim_el = self._find(item_el, "GUID", "BIMRef")
         if bim_el is not None:
             item.bim_guid = bim_el.text.strip() if bim_el.text else None
@@ -381,6 +418,10 @@ class BaseV3Parser:
         disc_str = self._text(item_el, "DiscountPcnt")
         if disc_str:
             item.discount_pct = _parse_decimal(disc_str)
+
+        vat_str = self._text(item_el, "VAT")
+        if vat_str:
+            item.vat = _parse_decimal(vat_str)
 
         item.ctlg_assigns = self._parse_ctlg_assigns(item_el)
 
@@ -519,6 +560,87 @@ class BaseV3Parser:
     def _parse_ctlg_assigns(self, parent: etree._Element) -> list[CtlgAssign]:
         """Parse all ``<CtlgAssign>`` children of *parent*."""
         return [self._parse_ctlg_assign(el) for el in self._findall(parent, "CtlgAssign")]
+
+    def _parse_totals(self, parent: etree._Element) -> Totals | None:
+        """Parse a ``<Totals>`` child element into a :class:`Totals` model."""
+        totals_el = self._find(parent, "Totals")
+        if totals_el is None:
+            return None
+
+        t = Totals()
+        t.total = _parse_decimal(self._text(totals_el, "Total"))
+        t.discount_pcnt = _parse_decimal(self._text(totals_el, "DiscountPcnt"))
+        t.discount_amt = _parse_decimal(self._text(totals_el, "DiscountAmt"))
+        t.tot_after_disc = _parse_decimal(self._text(totals_el, "TotAfterDisc"))
+        t.total_lsum = _parse_decimal(self._text(totals_el, "TotalLSUM"))
+        t.vat = _parse_decimal(self._text(totals_el, "VAT"))
+        t.total_net = _parse_decimal(self._text(totals_el, "TotalNet"))
+
+        up_comp_el = self._find(totals_el, "TotalNetUpComp")
+        if up_comp_el is not None:
+            for i in range(1, 7):
+                val = _parse_decimal(self._text(up_comp_el, f"UpComp{i}"))
+                if val is not None:
+                    while len(t.total_net_up_comp) < i:
+                        t.total_net_up_comp.append(Decimal("0"))
+                    t.total_net_up_comp[i - 1] = val
+
+        for vp_el in self._findall(totals_el, "VATPart"):
+            pcnt = _parse_decimal(vp_el.get("VATPcnt")) or Decimal("0")
+            vp = VATPart(
+                vat_pcnt=pcnt,
+                total_net_part=_parse_decimal(self._text(vp_el, "TotalNetPart")),
+                vat_amount=_parse_decimal(self._text(vp_el, "VATAmount")),
+            )
+            t.vat_parts.append(vp)
+
+        t.vat_amount = _parse_decimal(self._text(totals_el, "VATAmount"))
+        t.total_gross = _parse_decimal(self._text(totals_el, "TotalGross"))
+        return t
+
+    def _parse_item_attachments(self, item_el: etree._Element) -> list[Attachment]:
+        """Extract attachments from a procurement item's ``<Description>`` subtree.
+
+        Handles two patterns defined in the GAEB Lib schema:
+        - URI references: ``<attachment>`` elements (plain URI strings)
+        - Embedded images: ``<image>`` elements with base64 content and
+          ``Type``/``Name`` attributes
+        """
+        import base64
+
+        attachments: list[Attachment] = []
+
+        desc = self._find(item_el, "Description")
+        if desc is None:
+            return attachments
+
+        for att_el in desc.iter():
+            local = self._local_tag(att_el.tag)
+            if local == "attachment" and att_el.text and att_el.text.strip():
+                uri = att_el.text.strip()
+                attachments.append(Attachment(
+                    filename=uri,
+                    mime_type="application/octet-stream",
+                    data=b"",
+                ))
+            elif local == "image":
+                b64_text = att_el.text or ""
+                if not b64_text.strip():
+                    continue
+                mime = att_el.get("Type", "image/png")
+                name = att_el.get("Name", "embedded_image")
+                try:
+                    data = base64.b64decode(b64_text.strip())
+                except Exception:
+                    logger.warning("Failed to decode embedded image %s", name)
+                    continue
+                attachments.append(Attachment(
+                    filename=name,
+                    mime_type=mime,
+                    data=data,
+                ))
+
+        return attachments
 
     def _has_lot_bkdn(self) -> bool:
         return any(b.bkdn_type == BkdnType.LOT for b in self._bkdn)

--- a/pygaeb/writer/gaeb_writer.py
+++ b/pygaeb/writer/gaeb_writer.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from lxml import etree
 
-from pygaeb.models.boq import BoQ, BoQBody, BoQCtgy, BoQInfo
+from pygaeb.models.boq import BoQ, BoQBody, BoQCtgy, BoQInfo, Totals
 from pygaeb.models.catalog import Catalog, CtlgAssign
 from pygaeb.models.cost import (
     CategoryElement,
@@ -186,6 +186,7 @@ def _build_xml(
     root.set("xmlns", ns)
 
     _add_gaeb_info(root, doc.gaeb_info, meta)
+    _add_prj_info(root, doc.award)
     _add_award(root, doc.award, phase, meta, warnings)
 
     return root, warnings
@@ -201,6 +202,39 @@ def _add_gaeb_info(parent: etree._Element, info: GAEBInfo, meta: VersionMeta) ->
         gaeb_info, "ProgSystemVersion", info.prog_system_version or __version__,
     )
     _add_text_el(gaeb_info, "Date", datetime.now().strftime("%Y-%m-%d"))
+
+
+def _add_prj_info(parent: etree._Element, award: AwardInfo) -> None:
+    """Serialize PrjInfo fields from ``AwardInfo`` into a ``<PrjInfo>`` element."""
+    has_prj_data = any([
+        award.prj_id, award.lbl_prj, award.description,
+        award.currency_label, award.bid_comm_perm, award.alter_bid_perm,
+        award.up_frac_dig is not None, award.ctlg_assigns,
+    ])
+    if not has_prj_data:
+        return
+
+    prj_el = etree.SubElement(parent, "PrjInfo")
+    if award.project_name:
+        _add_text_el(prj_el, "NamePrj", award.project_name)
+    if award.prj_id:
+        _add_text_el(prj_el, "PrjID", award.prj_id)
+    if award.lbl_prj:
+        _add_text_el(prj_el, "LblPrj", award.lbl_prj)
+    if award.description:
+        _add_text_el(prj_el, "Descrip", award.description)
+    if award.currency:
+        _add_text_el(prj_el, "Cur", award.currency)
+    if award.currency_label:
+        _add_text_el(prj_el, "CurLbl", award.currency_label)
+    if award.bid_comm_perm:
+        _add_text_el(prj_el, "BidCommPerm", "Yes")
+    if award.alter_bid_perm:
+        _add_text_el(prj_el, "AlterBidPerm", "Yes")
+    if award.up_frac_dig is not None:
+        _add_text_el(prj_el, "UPFracDig", str(award.up_frac_dig))
+    for ca in award.ctlg_assigns:
+        _add_ctlg_assign(prj_el, ca)
 
 
 def _add_award(
@@ -239,6 +273,8 @@ def _add_boq(
             lot_ctgy = etree.SubElement(boq_body, "BoQCtgy")
             lot_ctgy.set("RNoPart", lot.rno)
             _add_text_el(lot_ctgy, "LblTx", lot.label)
+            if lot.totals is not None:
+                _add_totals(lot_ctgy, lot.totals)
             lot_body = etree.SubElement(lot_ctgy, "BoQBody")
             _add_body_categories(lot_body, lot.body, phase, meta, warnings)
         else:
@@ -264,6 +300,9 @@ def _add_boq_info(parent: etree._Element, info: BoQInfo) -> None:
     for ca in info.ctlg_assigns:
         _add_ctlg_assign(info_el, ca)
 
+    if info.totals is not None:
+        _add_totals(info_el, info.totals)
+
 
 def _add_body_categories(
     parent: etree._Element, body: BoQBody, phase: ExchangePhase,
@@ -285,6 +324,9 @@ def _add_ctgy(
 
     for ca in ctgy.ctlg_assigns:
         _add_ctlg_assign(ctgy_el, ca)
+
+    if ctgy.totals is not None:
+        _add_totals(ctgy_el, ctgy.totals)
 
     for sub in ctgy.subcategories:
         sub_body = etree.SubElement(ctgy_el, "BoQBody")
@@ -366,6 +408,9 @@ def _add_item(
 
     if item.discount_pct is not None:
         _add_text_el(item_el, "DiscountPcnt", _fmt_decimal(item.discount_pct))
+
+    if item.vat is not None:
+        _add_text_el(item_el, "VAT", _fmt_decimal(item.vat))
 
     for ctlg in item.ctlg_assigns:
         _add_ctlg_assign(item_el, ctlg)
@@ -527,6 +572,49 @@ def _add_boq_info_cost_types(parent: etree._Element, info: BoQInfo) -> None:
             _add_text_el(ct_el, "Name", ct.name)
         if ct.label:
             _add_text_el(ct_el, "Label", ct.label)
+
+
+def _add_totals(parent: etree._Element, totals: Totals) -> None:
+    """Serialize a ``Totals`` model to a ``<Totals>`` XML element."""
+    t_el = etree.SubElement(parent, "Totals")
+
+    if totals.total is not None:
+        _add_text_el(t_el, "Total", _fmt_decimal(totals.total))
+
+    if totals.discount_pcnt is not None:
+        _add_text_el(t_el, "DiscountPcnt", _fmt_decimal(totals.discount_pcnt))
+    if totals.discount_amt is not None:
+        _add_text_el(t_el, "DiscountAmt", _fmt_decimal(totals.discount_amt))
+    if totals.tot_after_disc is not None:
+        _add_text_el(t_el, "TotAfterDisc", _fmt_decimal(totals.tot_after_disc))
+
+    if totals.total_lsum is not None:
+        _add_text_el(t_el, "TotalLSUM", _fmt_decimal(totals.total_lsum))
+
+    if totals.vat is not None:
+        _add_text_el(t_el, "VAT", _fmt_decimal(totals.vat))
+
+    if totals.total_net is not None:
+        _add_text_el(t_el, "TotalNet", _fmt_decimal(totals.total_net))
+
+    if totals.total_net_up_comp:
+        uc_el = etree.SubElement(t_el, "TotalNetUpComp")
+        for i, comp in enumerate(totals.total_net_up_comp, 1):
+            _add_text_el(uc_el, f"UpComp{i}", _fmt_decimal(comp))
+
+    for vp in totals.vat_parts:
+        vp_el = etree.SubElement(t_el, "VATPart")
+        vp_el.set("VATPcnt", _fmt_decimal(vp.vat_pcnt))
+        if vp.total_net_part is not None:
+            _add_text_el(vp_el, "TotalNetPart", _fmt_decimal(vp.total_net_part))
+        if vp.vat_amount is not None:
+            _add_text_el(vp_el, "VATAmount", _fmt_decimal(vp.vat_amount))
+
+    if totals.vat_amount is not None:
+        _add_text_el(t_el, "VATAmount", _fmt_decimal(totals.vat_amount))
+
+    if totals.total_gross is not None:
+        _add_text_el(t_el, "TotalGross", _fmt_decimal(totals.total_gross))
 
 
 # ------------------------------------------------------------------

--- a/tests/test_procurement_gaps_v150.py
+++ b/tests/test_procurement_gaps_v150.py
@@ -1,0 +1,519 @@
+"""Tests for procurement gaps addressed in v1.5.0.
+
+Covers:
+- Totals (BoQInfo, BoQCtgy, Lot level) parsing and writing
+- VATPart (multiple VAT rates) parsing and writing
+- Item-level VAT parsing and writing
+- PrjInfo field completeness parsing and writing
+- Procurement item attachments (URI + embedded image)
+- Round-trip integrity
+- Default-empty regression on new fields
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from textwrap import dedent
+
+from pygaeb import (
+    ExchangePhase,
+    GAEBDocument,
+    GAEBParser,
+    GAEBWriter,
+    SourceVersion,
+)
+from pygaeb.api.document_api import DocumentAPI
+from pygaeb.models.boq import BoQ, BoQBody, BoQCtgy, BoQInfo, Lot, Totals, VATPart
+from pygaeb.models.document import AwardInfo
+from pygaeb.models.item import Item
+
+# ── XML Fixtures ─────────────────────────────────────────────────────
+
+PROCUREMENT_WITH_TOTALS = dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA86/3.3">
+      <GAEBInfo>
+        <Version>3.3</Version>
+        <ProgSystem>TestSuite</ProgSystem>
+      </GAEBInfo>
+      <PrjInfo>
+        <NamePrj>Test Project</NamePrj>
+        <PrjID>A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4</PrjID>
+        <LblPrj>Test Label</LblPrj>
+        <Descrip>A sample project description</Descrip>
+        <Cur>EUR</Cur>
+        <CurLbl>Euro</CurLbl>
+        <BidCommPerm>Yes</BidCommPerm>
+        <AlterBidPerm>Yes</AlterBidPerm>
+        <UPFracDig>3</UPFracDig>
+        <CtlgAssign>
+          <CtlgID>DIN276</CtlgID>
+          <CtlgCode>300</CtlgCode>
+        </CtlgAssign>
+      </PrjInfo>
+      <Award>
+        <AwardInfo>
+          <Prj>PRJ-001</Prj>
+          <PrjName>Test Project</PrjName>
+          <Cur>EUR</Cur>
+        </AwardInfo>
+        <BoQ>
+          <BoQInfo>
+            <Name>Main BoQ</Name>
+            <BoQBkdn>
+              <BoQLevel Length="2"/>
+              <Item Length="4"/>
+            </BoQBkdn>
+            <Totals>
+              <Total>10000.00</Total>
+              <DiscountPcnt>5.000000</DiscountPcnt>
+              <DiscountAmt>500.00</DiscountAmt>
+              <TotAfterDisc>9500.00</TotAfterDisc>
+              <VAT>19.00</VAT>
+              <TotalNet>9500.00</TotalNet>
+              <TotalNetUpComp>
+                <UpComp1>5000.00</UpComp1>
+                <UpComp2>4500.00</UpComp2>
+              </TotalNetUpComp>
+              <VATPart VATPcnt="19.00">
+                <TotalNetPart>8000.00</TotalNetPart>
+                <VATAmount>1520.00</VATAmount>
+              </VATPart>
+              <VATPart VATPcnt="7.00">
+                <TotalNetPart>1500.00</TotalNetPart>
+                <VATAmount>105.00</VATAmount>
+              </VATPart>
+              <VATAmount>1625.00</VATAmount>
+              <TotalGross>11125.00</TotalGross>
+            </Totals>
+          </BoQInfo>
+          <BoQBody>
+            <BoQCtgy RNoPart="01">
+              <LblTx>Section A</LblTx>
+              <Totals>
+                <Total>5000.00</Total>
+                <TotalNet>4750.00</TotalNet>
+                <TotalGross>5652.50</TotalGross>
+              </Totals>
+              <Itemlist>
+                <Item RNoPart="0001">
+                  <Qty>10.000</Qty>
+                  <QU>m2</QU>
+                  <UP>500.000</UP>
+                  <IT>5000.00</IT>
+                  <VAT>19.00</VAT>
+                </Item>
+              </Itemlist>
+            </BoQCtgy>
+            <BoQCtgy RNoPart="02">
+              <LblTx>Section B</LblTx>
+              <Itemlist>
+                <Item RNoPart="0001">
+                  <Qty>20.000</Qty>
+                  <QU>m</QU>
+                  <UP>250.000</UP>
+                  <IT>5000.00</IT>
+                  <VAT>7.00</VAT>
+                </Item>
+              </Itemlist>
+            </BoQCtgy>
+          </BoQBody>
+        </BoQ>
+      </Award>
+    </GAEB>
+""")
+
+ITEM_WITH_ATTACHMENTS = dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA83/3.3">
+      <GAEBInfo><Version>3.3</Version></GAEBInfo>
+      <Award>
+        <AwardInfo><Cur>EUR</Cur></AwardInfo>
+        <BoQ>
+          <BoQBody>
+            <BoQCtgy RNoPart="01">
+              <Itemlist>
+                <Item RNoPart="0001">
+                  <ShortText>Item with attachments</ShortText>
+                  <Description>
+                    <CompleteText>
+                      <DetailTxt>
+                        <attachment>https://example.com/plan.pdf</attachment>
+                        <Text><p>
+                          <image Type="image/png" Name="photo.png">iVBORw0KGgo=</image>
+                        </p></Text>
+                      </DetailTxt>
+                    </CompleteText>
+                  </Description>
+                  <Qty>1</Qty>
+                  <QU>pcs</QU>
+                </Item>
+              </Itemlist>
+            </BoQCtgy>
+          </BoQBody>
+        </BoQ>
+      </Award>
+    </GAEB>
+""")
+
+
+# ── Totals Tests ─────────────────────────────────────────────────────
+
+
+class TestTotalsParsingBoQInfo:
+    def _parse(self) -> GAEBDocument:
+        return GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+
+    def test_boq_info_totals_parsed(self) -> None:
+        doc = self._parse()
+        t = doc.award.boq.boq_info.totals
+        assert t is not None
+
+    def test_total(self) -> None:
+        t = self._parse().award.boq.boq_info.totals
+        assert t.total == Decimal("10000.00")
+
+    def test_discount_fields(self) -> None:
+        t = self._parse().award.boq.boq_info.totals
+        assert t.discount_pcnt == Decimal("5.000000")
+        assert t.discount_amt == Decimal("500.00")
+        assert t.tot_after_disc == Decimal("9500.00")
+
+    def test_vat_rate(self) -> None:
+        t = self._parse().award.boq.boq_info.totals
+        assert t.vat == Decimal("19.00")
+
+    def test_total_net(self) -> None:
+        t = self._parse().award.boq.boq_info.totals
+        assert t.total_net == Decimal("9500.00")
+
+    def test_total_net_up_comp(self) -> None:
+        t = self._parse().award.boq.boq_info.totals
+        assert len(t.total_net_up_comp) == 2
+        assert t.total_net_up_comp[0] == Decimal("5000.00")
+        assert t.total_net_up_comp[1] == Decimal("4500.00")
+
+    def test_vat_parts(self) -> None:
+        t = self._parse().award.boq.boq_info.totals
+        assert len(t.vat_parts) == 2
+        vp19 = t.vat_parts[0]
+        assert vp19.vat_pcnt == Decimal("19.00")
+        assert vp19.total_net_part == Decimal("8000.00")
+        assert vp19.vat_amount == Decimal("1520.00")
+        vp7 = t.vat_parts[1]
+        assert vp7.vat_pcnt == Decimal("7.00")
+        assert vp7.total_net_part == Decimal("1500.00")
+        assert vp7.vat_amount == Decimal("105.00")
+
+    def test_vat_amount(self) -> None:
+        t = self._parse().award.boq.boq_info.totals
+        assert t.vat_amount == Decimal("1625.00")
+
+    def test_total_gross(self) -> None:
+        t = self._parse().award.boq.boq_info.totals
+        assert t.total_gross == Decimal("11125.00")
+
+
+class TestTotalsParsingBoQCtgy:
+    def _parse(self) -> GAEBDocument:
+        return GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+
+    def test_ctgy_with_totals(self) -> None:
+        doc = self._parse()
+        ctgy = doc.award.boq.lots[0].body.categories[0]
+        assert ctgy.totals is not None
+        assert ctgy.totals.total == Decimal("5000.00")
+        assert ctgy.totals.total_net == Decimal("4750.00")
+        assert ctgy.totals.total_gross == Decimal("5652.50")
+
+    def test_ctgy_without_totals(self) -> None:
+        doc = self._parse()
+        ctgy = doc.award.boq.lots[0].body.categories[1]
+        assert ctgy.totals is None
+
+
+class TestTotalsWriteRoundTrip:
+    def test_boq_info_totals_roundtrip(self) -> None:
+        doc = GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+        xml_bytes, _ = GAEBWriter.to_bytes(doc, target_version=SourceVersion.DA_XML_33)
+        doc2 = GAEBParser.parse_string(xml_bytes.decode("utf-8"))
+
+        t = doc2.award.boq.boq_info.totals
+        assert t is not None
+        assert t.total == Decimal("10000.00")
+        assert t.discount_pcnt == Decimal("5.000000")
+        assert t.vat == Decimal("19.00")
+        assert t.total_net == Decimal("9500.00")
+        assert len(t.vat_parts) == 2
+        assert t.vat_amount == Decimal("1625.00")
+        assert t.total_gross == Decimal("11125.00")
+
+    def test_ctgy_totals_roundtrip(self) -> None:
+        doc = GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+        xml_bytes, _ = GAEBWriter.to_bytes(doc, target_version=SourceVersion.DA_XML_33)
+        doc2 = GAEBParser.parse_string(xml_bytes.decode("utf-8"))
+
+        ctgy = doc2.award.boq.lots[0].body.categories[0]
+        assert ctgy.totals is not None
+        assert ctgy.totals.total == Decimal("5000.00")
+
+    def test_totals_model_direct(self) -> None:
+        """Build a Totals model from scratch and verify writing."""
+        totals = Totals(
+            total=Decimal("1000"),
+            total_lsum=Decimal("1000"),
+            vat=Decimal("19"),
+            total_gross=Decimal("1190"),
+        )
+        doc = GAEBDocument(
+            exchange_phase=ExchangePhase.X86,
+            award=AwardInfo(
+                project_name="Direct Test",
+                boq=BoQ(
+                    boq_info=BoQInfo(name="B1", totals=totals),
+                    lots=[Lot(rno="1", label="L1", body=BoQBody())],
+                ),
+            ),
+        )
+        xml_bytes, _ = GAEBWriter.to_bytes(doc)
+        content = xml_bytes.decode("utf-8")
+        assert "<TotalLSUM>1000</TotalLSUM>" in content
+        assert "<TotalGross>1190</TotalGross>" in content
+
+
+# ── Item-level VAT Tests ─────────────────────────────────────────────
+
+
+class TestItemVAT:
+    def test_item_vat_parsed(self) -> None:
+        doc = GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+        items = list(doc.award.boq.iter_items())
+        assert items[0].vat == Decimal("19.00")
+        assert items[1].vat == Decimal("7.00")
+
+    def test_item_vat_roundtrip(self) -> None:
+        doc = GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+        xml_bytes, _ = GAEBWriter.to_bytes(doc, target_version=SourceVersion.DA_XML_33)
+        doc2 = GAEBParser.parse_string(xml_bytes.decode("utf-8"))
+        items = list(doc2.award.boq.iter_items())
+        assert items[0].vat == Decimal("19.00")
+        assert items[1].vat == Decimal("7.00")
+
+    def test_item_vat_default_none(self) -> None:
+        item = Item(oz="001")
+        assert item.vat is None
+
+
+# ── PrjInfo Tests ────────────────────────────────────────────────────
+
+
+class TestPrjInfoParsing:
+    def _parse(self) -> GAEBDocument:
+        return GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+
+    def test_prj_id(self) -> None:
+        award = self._parse().award
+        assert award.prj_id == "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4"
+
+    def test_lbl_prj(self) -> None:
+        assert self._parse().award.lbl_prj == "Test Label"
+
+    def test_description(self) -> None:
+        assert self._parse().award.description == "A sample project description"
+
+    def test_currency_label(self) -> None:
+        assert self._parse().award.currency_label == "Euro"
+
+    def test_bid_comm_perm(self) -> None:
+        assert self._parse().award.bid_comm_perm is True
+
+    def test_alter_bid_perm(self) -> None:
+        assert self._parse().award.alter_bid_perm is True
+
+    def test_up_frac_dig(self) -> None:
+        assert self._parse().award.up_frac_dig == 3
+
+    def test_ctlg_assigns(self) -> None:
+        assigns = self._parse().award.ctlg_assigns
+        assert len(assigns) == 1
+        assert assigns[0].ctlg_id == "DIN276"
+        assert assigns[0].ctlg_code == "300"
+
+
+class TestPrjInfoWriteRoundTrip:
+    def test_prjinfo_roundtrip(self) -> None:
+        doc = GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+        xml_bytes, _ = GAEBWriter.to_bytes(doc, target_version=SourceVersion.DA_XML_33)
+        content = xml_bytes.decode("utf-8")
+
+        assert "<PrjInfo>" in content
+        assert "<NamePrj>Test Project</NamePrj>" in content
+        assert "<PrjID>A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4</PrjID>" in content
+        assert "<LblPrj>Test Label</LblPrj>" in content
+        assert "<Descrip>A sample project description</Descrip>" in content
+        assert "<CurLbl>Euro</CurLbl>" in content
+        assert "<BidCommPerm>Yes</BidCommPerm>" in content
+        assert "<AlterBidPerm>Yes</AlterBidPerm>" in content
+        assert "<UPFracDig>3</UPFracDig>" in content
+
+    def test_prjinfo_reparse(self) -> None:
+        doc = GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+        xml_bytes, _ = GAEBWriter.to_bytes(doc, target_version=SourceVersion.DA_XML_33)
+        doc2 = GAEBParser.parse_string(xml_bytes.decode("utf-8"))
+
+        assert doc2.award.prj_id == "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4"
+        assert doc2.award.lbl_prj == "Test Label"
+        assert doc2.award.description == "A sample project description"
+        assert doc2.award.currency_label == "Euro"
+        assert doc2.award.bid_comm_perm is True
+        assert doc2.award.alter_bid_perm is True
+        assert doc2.award.up_frac_dig == 3
+
+    def test_prjinfo_defaults_no_element(self) -> None:
+        """AwardInfo with no PrjInfo data should not emit a <PrjInfo> element."""
+        doc = GAEBDocument(
+            award=AwardInfo(currency="EUR"),
+        )
+        xml_bytes, _ = GAEBWriter.to_bytes(doc)
+        assert b"<PrjInfo>" not in xml_bytes
+
+
+# ── Attachment Tests ─────────────────────────────────────────────────
+
+
+class TestProcurementAttachments:
+    def test_uri_attachment_parsed(self) -> None:
+        doc = GAEBParser.parse_string(ITEM_WITH_ATTACHMENTS)
+        items = list(doc.award.boq.iter_items())
+        assert len(items) == 1
+        uri_attachments = [a for a in items[0].attachments if a.data == b""]
+        assert len(uri_attachments) == 1
+        assert uri_attachments[0].filename == "https://example.com/plan.pdf"
+
+    def test_embedded_image_parsed(self) -> None:
+        doc = GAEBParser.parse_string(ITEM_WITH_ATTACHMENTS)
+        items = list(doc.award.boq.iter_items())
+        img_attachments = [a for a in items[0].attachments if a.data != b""]
+        assert len(img_attachments) == 1
+        assert img_attachments[0].filename == "photo.png"
+        assert img_attachments[0].mime_type == "image/png"
+        assert len(img_attachments[0].data) > 0
+
+    def test_no_attachments_default(self) -> None:
+        xml = dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA83/3.3">
+              <GAEBInfo><Version>3.3</Version></GAEBInfo>
+              <Award>
+                <AwardInfo><Cur>EUR</Cur></AwardInfo>
+                <BoQ><BoQBody>
+                  <BoQCtgy RNoPart="01">
+                    <Itemlist>
+                      <Item RNoPart="0001">
+                        <ShortText>No attachments</ShortText>
+                        <Qty>1</Qty>
+                      </Item>
+                    </Itemlist>
+                  </BoQCtgy>
+                </BoQBody></BoQ>
+              </Award>
+            </GAEB>
+        """)
+        doc = GAEBParser.parse_string(xml)
+        items = list(doc.award.boq.iter_items())
+        assert items[0].attachments == []
+
+
+# ── DocumentAPI Summary Tests ────────────────────────────────────────
+
+
+class TestDocumentAPISummary:
+    def test_summary_includes_totals(self) -> None:
+        doc = GAEBParser.parse_string(PROCUREMENT_WITH_TOTALS)
+        api = DocumentAPI(doc)
+        s = api.summary()
+        assert s["total_net"] == "9500.00"
+        assert s["total_gross"] == "11125.00"
+        assert s["vat_rate"] == "19.00"
+        assert s["vat_amount"] == "1625.00"
+        assert s["up_frac_dig"] == 3
+
+
+# ── Default-empty Regression Tests ───────────────────────────────────
+
+
+class TestNoRegressionOnNewFields:
+    def test_item_vat_default(self) -> None:
+        item = Item()
+        assert item.vat is None
+
+    def test_boq_info_totals_default(self) -> None:
+        info = BoQInfo()
+        assert info.totals is None
+
+    def test_boq_ctgy_totals_default(self) -> None:
+        ctgy = BoQCtgy()
+        assert ctgy.totals is None
+
+    def test_lot_totals_default(self) -> None:
+        lot = Lot()
+        assert lot.totals is None
+
+    def test_award_prjinfo_defaults(self) -> None:
+        award = AwardInfo()
+        assert award.prj_id is None
+        assert award.lbl_prj is None
+        assert award.description is None
+        assert award.currency_label is None
+        assert award.bid_comm_perm is False
+        assert award.alter_bid_perm is False
+        assert award.up_frac_dig is None
+        assert award.ctlg_assigns == []
+
+    def test_totals_model_defaults(self) -> None:
+        t = Totals()
+        assert t.total is None
+        assert t.discount_pcnt is None
+        assert t.vat is None
+        assert t.total_net is None
+        assert t.total_gross is None
+        assert t.vat_parts == []
+        assert t.total_net_up_comp == []
+
+    def test_vat_part_model(self) -> None:
+        vp = VATPart(vat_pcnt=Decimal("19"), total_net_part=Decimal("100"))
+        assert vp.vat_pcnt == Decimal("19")
+        assert vp.total_net_part == Decimal("100")
+        assert vp.vat_amount is None
+
+
+# ── Lot-level Totals Tests ───────────────────────────────────────────
+
+
+class TestLotTotals:
+    def test_lot_totals_write_roundtrip(self) -> None:
+        """Build a multi-lot doc with lot-level totals and verify round-trip."""
+        lot1 = Lot(
+            rno="1", label="Lot A",
+            body=BoQBody(),
+            totals=Totals(total=Decimal("5000"), total_gross=Decimal("5950")),
+        )
+        lot2 = Lot(
+            rno="2", label="Lot B",
+            body=BoQBody(),
+            totals=Totals(total=Decimal("3000"), total_gross=Decimal("3570")),
+        )
+        doc = GAEBDocument(
+            exchange_phase=ExchangePhase.X86,
+            award=AwardInfo(
+                project_name="Multi-Lot",
+                boq=BoQ(
+                    boq_info=BoQInfo(name="ML"),
+                    lots=[lot1, lot2],
+                ),
+            ),
+        )
+        xml_bytes, _ = GAEBWriter.to_bytes(doc)
+        content = xml_bytes.decode("utf-8")
+        assert "<TotalGross>5950</TotalGross>" in content
+        assert "<TotalGross>3570</TotalGross>" in content


### PR DESCRIPTION
- Add Totals and VATPart models for authoritative financial summaries at BoQInfo, BoQCtgy, and Lot levels (net, gross, discounts, multi-rate VAT)
- Parse and write item-level VAT percentages
- Extend AwardInfo with complete PrjInfo fields (project GUID, label, description, currency label, bid permissions, unit price decimal places)
- Wire procurement item attachment extraction (URI refs + embedded images)
- Expose totals and PrjInfo in DocumentAPI.summary()
- Export Totals and VATPart from pygaeb public API
- Add 40 round-trip tests (tests/test_procurement_gaps_v150.py)
- Update docs: parsing guide, quickstart, models reference, changelog