### PR TITLE
feat: security hardening & extensibility (v1.6.0 + v1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,23 @@
 
 **Python parser for GAEB DA XML construction data exchange files, with LLM-powered item classification.**
 
+[![PyPI version](https://img.shields.io/badge/version-1.7.0-blue.svg)](https://pypi.org/project/pyGAEB/)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-pyGAEB parses, validates, classifies, and writes GAEB DA XML files (versions 2.0 through 3.3), producing a unified Pydantic v2 domain model from all inputs. An optional LLM classification layer enriches each item with a semantic construction element type via [LiteLLM](https://github.com/BerriAI/litellm) (100+ providers).
+pyGAEB parses, validates, classifies, and writes GAEB DA XML files (versions 2.0 through 3.3), producing a unified Pydantic v2 domain model from all inputs. It supports the full GAEB exchange phase spectrum — procurement (X80–X89), trade (X93–X97), cost & calculation (X50–X52), and quantity determination (X31).
+
+An optional LLM classification layer enriches each item with a semantic construction element type via [LiteLLM](https://github.com/BerriAI/litellm) (100+ providers), with pluggable caching and customisable taxonomy.
+
+## Highlights
+
+- **Multi-version** — DA XML 2.0, 2.1, 3.0, 3.1, 3.2, 3.3 auto-detected
+- **All exchange phases** — Procurement, Trade, Cost & Calculation, Quantity Determination
+- **Security-hardened** — XXE prevention, Billion Laughs protection, file size guards, recursion depth limits
+- **Extensible** — Custom validators, post-parse hooks, raw XML data collection, custom LLM taxonomy
+- **LLM classification** — 100+ provider support via LiteLLM with cost estimation and persistent caching
+- **Round-trip** — Parse → modify → write back to any DA XML version
+- **Version conversion** — Upgrade/downgrade between DA XML 2.0–3.3
 
 ## Installation
 
@@ -34,8 +47,10 @@ print(doc.grand_total)                  # Decimal("1234567.89")
 
 ### Iterate items
 
+Works for all document kinds — procurement, trade, cost, and quantity:
+
 ```python
-for item in doc.award.boq.iter_items():
+for item in doc.iter_items():
     print(item.oz)              # "01.02.0030"
     print(item.short_text)      # "Mauerwerk der Innenwand…"
     print(item.qty)             # Decimal("1170.000")
@@ -59,6 +74,35 @@ for issue in doc.validation_results:
 doc = GAEBParser.parse("tender.X83", validation=ValidationMode.STRICT)
 ```
 
+### Custom Validators
+
+Register project-specific validation rules:
+
+```python
+from pygaeb import register_validator, clear_validators
+from pygaeb.models.item import ValidationResult
+from pygaeb.models.enums import ValidationSeverity
+
+def require_unit(doc):
+    issues = []
+    for item in doc.iter_items():
+        if not item.unit:
+            issues.append(
+                ValidationResult(
+                    severity=ValidationSeverity.WARNING,
+                    message=f"{item.oz}: missing unit",
+                )
+            )
+    return issues
+
+register_validator(require_unit)
+doc = GAEBParser.parse("tender.X83")
+# require_unit results are now in doc.validation_results
+
+# Or per-call (not added to the global registry):
+doc = GAEBParser.parse("tender.X83", extra_validators=[require_unit])
+```
+
 ### Write / Round-trip
 
 ```python
@@ -72,6 +116,22 @@ item.unit_price = Decimal("48.00")
 GAEBWriter.write(doc, "bid.X84", phase=ExchangePhase.X84)
 ```
 
+### Version Conversion
+
+```python
+from pygaeb import GAEBConverter, SourceVersion
+
+# Upgrade 2.x → 3.3
+report = GAEBConverter.convert("old.D83", "modern.X83")
+
+# Downgrade 3.3 → 3.2 for compatibility
+report = GAEBConverter.convert(
+    "tender.X83", "compat.X83",
+    target_version=SourceVersion.DA_XML_32,
+)
+print(f"Converted {report.items_converted} items, data loss: {report.has_data_loss}")
+```
+
 ### Export to JSON / CSV
 
 ```python
@@ -79,6 +139,56 @@ from pygaeb.convert import to_json, to_csv
 
 to_json(doc, "boq.json")     # full nested BoQ tree
 to_csv(doc, "items.csv")     # flat item table with classification columns
+```
+
+### Trade Phases (X93–X97)
+
+```python
+doc = GAEBParser.parse("order.X96")
+print(doc.document_kind)    # DocumentKind.TRADE
+print(doc.is_trade)         # True
+
+for item in doc.order.items:
+    print(item.art_no, item.short_text, item.net_price)
+
+print(doc.order.supplier_info.address.name)
+```
+
+### Cost & Calculation Phases (X50–X52)
+
+```python
+doc = GAEBParser.parse("costing.X50")
+print(doc.document_kind)    # DocumentKind.COST
+
+for elem in doc.elemental_costing.body.iter_cost_elements():
+    print(elem.ele_no, elem.short_text, elem.total_cost)
+```
+
+### Quantity Determination (X31)
+
+```python
+doc = GAEBParser.parse("measurements.X31")
+print(doc.document_kind)    # DocumentKind.QUANTITY
+
+for item in doc.qty_determination.boq.iter_items():
+    print(item.oz, item.qty_determ_items)
+```
+
+### Financial Summaries & Project Info
+
+```python
+doc = GAEBParser.parse("tender.X86")
+
+# BoQ-level totals
+totals = doc.award.boq.info.totals
+print(totals.total_net, totals.total_gross, totals.vat_amount)
+
+# Per-VAT-rate breakdown
+for vp in totals.vat_parts:
+    print(f"{vp.vat_pcnt}%: net {vp.net_amount} → gross {vp.gross_amount}")
+
+# Project metadata
+print(doc.award.prj_id, doc.award.description, doc.award.currency_label)
 ```
 
 ### LLM Classification
@@ -93,7 +203,14 @@ classifier = LLMClassifier(model="anthropic/claude-sonnet-4-6")
 
 # Opt-in: persistent SQLite cache (survives across runs)
 from pygaeb import SQLiteCache
-classifier = LLMClassifier(model="anthropic/claude-sonnet-4-6", cache=SQLiteCache("~/.pygaeb/cache"))
+classifier = LLMClassifier(cache=SQLiteCache("~/.pygaeb/cache"))
+
+# Custom taxonomy and prompt
+classifier = LLMClassifier(
+    model="openai/gpt-4o",
+    taxonomy={"Electrical": {"Cable": ["Ladder", "Perforated"]}},
+    prompt_template="You are a specialist classifying MEP items...",
+)
 
 # Check cost before running
 estimate = await classifier.estimate_cost(doc)
@@ -105,7 +222,7 @@ await classifier.enrich(doc)
 # Or synchronous
 classifier.enrich_sync(doc)
 
-for item in doc.award.boq.iter_items():
+for item in doc.iter_items():
     if item.classification:
         print(item.oz, item.classification.element_type, item.classification.confidence)
 ```
@@ -143,21 +260,58 @@ doors = extractor.extract_sync(doc, schema=DoorSpec, element_type="Door")
 
 Built-in starter schemas: `DoorSpec`, `WindowSpec`, `WallSpec`, `PipeSpec` — or define your own.
 
+### Post-Parse Hook & Raw Data Collection
+
+Extract vendor-specific XML elements during parsing:
+
+```python
+def extract_vendor_codes(item, el):
+    if el is None:
+        return
+    ns = {"g": "http://www.gaeb.de/GAEB_DA_XML/DA86/3.3"}
+    codes = el.findall(".//g:VendorCostCode", ns)
+    if codes:
+        item.raw_data = item.raw_data or {}
+        item.raw_data["vendor_codes"] = [c.text for c in codes]
+
+doc = GAEBParser.parse("file.X83", post_parse_hook=extract_vendor_codes)
+```
+
+Or automatically collect all unknown XML elements:
+
+```python
+doc = GAEBParser.parse("file.X83", collect_raw_data=True)
+for item in doc.iter_items():
+    if item.raw_data:
+        print(f"{item.oz}: extra fields = {item.raw_data}")
+```
+
+### Custom & Vendor Tags (XPath)
+
+```python
+doc = GAEBParser.parse("vendor_file.X83", keep_xml=True)
+
+# XPath across the whole document
+codes = doc.xpath("//g:VendorCostCode/text()")
+
+# Per-item raw element access
+for item in doc.iter_items():
+    el = item.source_element  # original lxml element
+
+# Free memory when done
+doc.discard_xml()
+```
+
 ### Custom Cache Backend
 
 ```python
 from pygaeb import CacheBackend, InMemoryCache, SQLiteCache
 
-# Default: in-memory (no disk, session-scoped)
+# Default: in-memory (LRU-bounded, session-scoped)
 classifier = LLMClassifier()
 
 # Persistent: SQLite
 classifier = LLMClassifier(cache=SQLiteCache("~/.pygaeb/cache"))
-
-# Share one backend between classifier and extractor
-shared = SQLiteCache("/tmp/project-cache")
-classifier = LLMClassifier(cache=shared)
-extractor = StructuredExtractor(cache=shared)
 
 # Bring your own: implement CacheBackend protocol
 class RedisCache:
@@ -184,29 +338,71 @@ for issue in issues:
     print(issue.severity, issue.message)
 ```
 
-## Supported Versions
+## Supported Versions & Exchange Phases
 
 | Version | Parser Track | Status |
 |---------|-------------|--------|
-| DA XML 2.0 | Track A (German elements) | ✅ v1.0 |
-| DA XML 2.1 | Track A (German elements) | ✅ v1.0 |
-| DA XML 3.0 | Track B (English elements) | ✅ v1.0 |
-| DA XML 3.1 | Track B (English elements) | ✅ v1.0 |
-| DA XML 3.2 | Track B (English elements) | ✅ v1.0 |
-| DA XML 3.3 | Track B (English elements) | ✅ v1.0 |
-| GAEB 90 | Track C (fixed-width) | 🔜 v1.1 |
+| DA XML 2.0 | Track A (German elements) | v1.0 |
+| DA XML 2.1 | Track A (German elements) | v1.0 |
+| DA XML 3.0 | Track B (English elements) | v1.0 |
+| DA XML 3.1 | Track B (English elements) | v1.0 |
+| DA XML 3.2 | Track B (English elements) | v1.0 |
+| DA XML 3.3 | Track B (English elements) | v1.0 |
+| GAEB 90 | Track C (fixed-width) | Planned |
+
+| Phase | Description | Since |
+|-------|-------------|-------|
+| X31 | Quantity Determination | v1.4.0 |
+| X50, X51, X52 | Cost & Calculation | v1.3.0 |
+| X80–X89 | Procurement (tender, bid, award, invoice) | v1.0.0 |
+| X93, X94, X96, X97 | Trade (material ordering) | v1.2.0 |
 
 ## Configuration
 
+```python
+from pygaeb import configure
+
+configure(
+    default_model="ollama/llama3",        # LLM model for classification
+    classifier_concurrency=10,            # parallel LLM calls
+    xsd_dir="/opt/gaeb-schemas",          # optional XSD validation
+    log_level="DEBUG",                    # applied to pygaeb.* loggers
+    max_file_size_mb=200,                 # input file size limit
+)
+```
+
+Or via environment variables:
+
 ```bash
-# Environment variables
 export PYGAEB_DEFAULT_MODEL=ollama/llama3
 export PYGAEB_XSD_DIR=/opt/gaeb-schemas
-
-# Or programmatic
-from pygaeb import PyGAEBSettings
-settings = PyGAEBSettings(default_model="gpt-4o", classifier_concurrency=10)
+export PYGAEB_LOG_LEVEL=DEBUG
+export PYGAEB_MAX_FILE_SIZE_MB=200
 ```
+
+## Security
+
+pyGAEB includes security hardening since v1.6.0:
+
+- **XXE prevention** — All XML parsing uses hardened parsers with `resolve_entities=False` and `no_network=True`
+- **Billion Laughs protection** — Entity expansion bombs are blocked
+- **File size guard** — Configurable limit (default 100 MB) prevents memory exhaustion
+- **Recursion depth limits** — Hierarchy walkers cap at 50 levels to prevent stack overflow
+- **Bounded caching** — `InMemoryCache` uses LRU eviction (default 10,000 entries)
+
+## Documentation
+
+Full documentation is available at [Read the Docs](https://pygaeb.readthedocs.io/).
+
+- [Quick Start](https://pygaeb.readthedocs.io/getting-started/quickstart/)
+- [Parsing Guide](https://pygaeb.readthedocs.io/guides/parsing/)
+- [Trade Phases](https://pygaeb.readthedocs.io/guides/trade-phases/)
+- [Cost & Calculation](https://pygaeb.readthedocs.io/guides/cost-phases/)
+- [Quantity Determination](https://pygaeb.readthedocs.io/guides/quantity-phases/)
+- [Extensibility](https://pygaeb.readthedocs.io/guides/extensibility/)
+- [Classification](https://pygaeb.readthedocs.io/guides/classification/)
+- [Version Conversion](https://pygaeb.readthedocs.io/guides/conversion/)
+- [API Reference](https://pygaeb.readthedocs.io/reference/)
 
 ## License
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,39 @@ All notable changes to pyGAEB are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-03-15
+
+### Added
+
+- **Custom validator registry** — `register_validator()` / `clear_validators()` for project-specific validation rules that run after the built-in pipeline. Per-call validators via `extra_validators=` on `GAEBParser.parse()`.
+- **Post-parse hook** — `post_parse_hook=` callback on `GAEBParser.parse()` / `parse_bytes()` / `parse_string()` receives `(item, source_element)` for each parsed item. Auto-enables `keep_xml` and discards afterwards when needed.
+- **`collect_raw_data`** — `GAEBParser.parse(..., collect_raw_data=True)` populates `item.raw_data` with XML child elements the parser did not consume.
+- **Custom LLM taxonomy & prompt** — `LLMClassifier(taxonomy=..., prompt_template=...)` for per-instance overrides. `register_prompt()` for reusable prompt templates.
+- **`log_level` applied** — The `log_level` setting is now applied to the `pygaeb` logger on `get_settings()` and `configure()`.
+- New exports: `register_validator`, `clear_validators`, `reset_settings`, `register_prompt`.
+- New guide: [Extensibility](guides/extensibility.md).
+
+## [1.6.0] - 2026-03-15
+
+### Security
+
+- **XXE prevention** — All XML parsing now uses hardened `lxml.XMLParser` with `resolve_entities=False`, `no_network=True`, and `huge_tree=False`. External entity injection and Billion Laughs attacks are blocked.
+- **File size guard** — New `max_file_size` parameter on `GAEBParser.parse()`, `parse_bytes()`, and `parse_string()`. Default limit: 100 MB (configurable via `max_file_size_mb` setting). Prevents memory exhaustion from oversized inputs.
+- **ReDoS removal** — Removed unused `_UNCLOSED_TAG_RE` regex that had catastrophic backtracking potential.
+
+### Fixed
+
+- **Recursion depth limits** — Hierarchy walkers (`_walk_ctgy`, `_walk_ec_ctgy`, `_walk_qty_ctgy`) now cap at 50 levels to prevent stack overflow on malicious/deep structures. `BoQCtgy.iter_items()`, `QtyBoQCtgy.iter_items()`, and `CostElement.iter_cost_elements()` converted from recursive to iterative.
+- **InMemoryCache bounded** — Now uses LRU eviction with a default `maxsize=10,000` entries to prevent unbounded growth in long-running processes.
+- **SQLiteCache resource cleanup** — Added `__del__` fallback to close connections. Cursors are now explicitly closed after each query.
+- **XSD validation memory** — Reuses the parsed XML tree (when `keep_xml=True`) instead of reparsing. XSD files opened with explicit file handles.
+
+### Added
+
+- `GAEBDocument.discard_xml()` — Releases the retained lxml tree and all `source_element` references to free memory after XPath/raw-element work is done.
+- `pygaeb.parser._xml_safety` — Shared module with `SAFE_PARSER`, `SAFE_RECOVER_PARSER`, and `safe_iterparse()` constants.
+- `max_file_size_mb` setting in `PyGAEBSettings` (default 100).
+
 ## [1.5.0] - 2026-03-15
 
 ### Added

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -247,12 +247,41 @@ LLM classification, structured extraction, and all other features work on trade 
 
 See the [Trade Phases Guide](../guides/trade-phases.md) for full details.
 
+## Custom Validation
+
+Register project-specific rules that run alongside the built-in validators:
+
+```python
+from pygaeb import register_validator
+from pygaeb.models.item import ValidationResult
+from pygaeb.models.enums import ValidationSeverity
+
+def require_unit(doc):
+    issues = []
+    for item in doc.iter_items():
+        if not item.unit:
+            issues.append(
+                ValidationResult(
+                    severity=ValidationSeverity.WARNING,
+                    message=f"{item.oz}: missing unit",
+                )
+            )
+    return issues
+
+register_validator(require_unit)
+doc = GAEBParser.parse("tender.X83")
+# Your rule's results are merged into doc.validation_results
+```
+
+See the [Extensibility Guide](../guides/extensibility.md) for post-parse hooks, custom LLM taxonomy, and more.
+
 ## Next Steps
 
 - [Parsing Guide](../guides/parsing.md) — version detection, encoding repair, error recovery
 - [Trade Phases](../guides/trade-phases.md) — working with X93–X97 trade orders
 - [Version Conversion](../guides/conversion.md) — convert between DA XML 2.0–3.3, upgrade, downgrade
 - [Custom & Vendor Tags](../guides/custom-tags.md) — raw XML access, XPath queries, vendor extensions
+- [Extensibility](../guides/extensibility.md) — custom validators, hooks, LLM prompts, raw data
 - [Classification Guide](../guides/classification.md) — LLM setup, taxonomy, confidence flags
 - [Extraction Guide](../guides/extraction.md) — custom Pydantic schemas for structured output
 - [API Reference](../reference/index.md) — full class and function documentation

--- a/docs/guides/extensibility.md
+++ b/docs/guides/extensibility.md
@@ -1,0 +1,119 @@
+# Extensibility
+
+pyGAEB v1.7.0 introduces five extension points that let you tailor parsing, validation, and classification to your project without forking the library.
+
+## Custom Validators
+
+Register project-specific validation rules that run after the built-in pipeline:
+
+```python
+from pygaeb import GAEBParser, register_validator, clear_validators
+from pygaeb.models.item import ValidationResult
+from pygaeb.models.enums import ValidationSeverity
+
+def require_unit(doc):
+    """Every item must specify a quantity unit."""
+    issues = []
+    for item in doc.iter_items():
+        if not item.unit:
+            issues.append(
+                ValidationResult(
+                    severity=ValidationSeverity.WARNING,
+                    message=f"{item.oz}: missing unit",
+                )
+            )
+    return issues
+
+register_validator(require_unit)
+doc = GAEBParser.parse("tender.X83")
+# require_unit results are now in doc.validation_results
+```
+
+Per-call validators are also supported — they are not added to the global registry:
+
+```python
+doc = GAEBParser.parse("tender.X83", extra_validators=[require_unit])
+```
+
+Call `clear_validators()` to remove all globally registered validators (useful in tests).
+
+## Post-Parse Hook
+
+The `post_parse_hook` callback is called with `(item, source_element)` for every parsed item. Use it to extract vendor-specific XML elements into `item.raw_data`:
+
+```python
+def extract_vendor_codes(item, el):
+    if el is None:
+        return
+    ns = {"g": "http://www.gaeb.de/GAEB_DA_XML/DA86/3.3"}
+    codes = el.findall(".//g:VendorCostCode", ns)
+    if codes:
+        item.raw_data = item.raw_data or {}
+        item.raw_data["vendor_codes"] = [c.text for c in codes]
+
+doc = GAEBParser.parse("file.X83", post_parse_hook=extract_vendor_codes)
+```
+
+If `keep_xml=False` (the default), pyGAEB auto-enables XML retention for the hook, then discards it afterwards to free memory.
+
+## Collect Unknown XML Elements
+
+Set `collect_raw_data=True` to automatically populate `item.raw_data` with any XML child elements the parser did not consume:
+
+```python
+doc = GAEBParser.parse("file.X83", collect_raw_data=True)
+for item in doc.iter_items():
+    if item.raw_data:
+        print(f"{item.oz}: extra fields = {item.raw_data}")
+```
+
+This is useful for discovering vendor extensions or non-standard elements without writing a custom hook.
+
+## Custom Taxonomy and Prompt for LLM Classification
+
+Override the built-in trade taxonomy and/or the system prompt per classifier instance:
+
+```python
+from pygaeb import LLMClassifier
+
+my_taxonomy = {
+    "Electrical": {"Cable Tray": ["Ladder", "Perforated"], "Panel": ["MCC", "DB"]},
+    "HVAC": {"AHU": ["Rooftop", "Indoor"], "Duct": ["Galvanised", "Flexible"]},
+}
+
+my_prompt = "You are a specialist classifying MEP items. Use these trades: ..."
+
+classifier = LLMClassifier(
+    model="openai/gpt-4o",
+    taxonomy=my_taxonomy,
+    prompt_template=my_prompt,
+)
+await classifier.enrich(doc)
+```
+
+You can also register reusable prompt templates:
+
+```python
+from pygaeb import register_prompt
+
+register_prompt("mep-v1", "You are classifying MEP items...")
+
+classifier = LLMClassifier(prompt_version="mep-v1")
+```
+
+## Configuring Log Level
+
+The `log_level` setting is now applied to the `pygaeb` logger automatically:
+
+```python
+from pygaeb import configure
+
+configure(log_level="DEBUG")
+# All pygaeb.* loggers now emit DEBUG messages
+```
+
+You can also set it via environment variable:
+
+```bash
+export PYGAEB_LOG_LEVEL=DEBUG
+```

--- a/docs/guides/parsing.md
+++ b/docs/guides/parsing.md
@@ -236,3 +236,35 @@ for item in doc.iter_items():
 ```
 
 See the [Models Reference](../reference/models.md) for full details on every field.
+
+## Advanced Parsing Options
+
+### Post-parse hook
+
+Use `post_parse_hook` to inspect or mutate each item right after parsing:
+
+```python
+def extract_vendor_codes(item, el):
+    if el is None:
+        return
+    ns = {"g": "http://www.gaeb.de/GAEB_DA_XML/DA86/3.3"}
+    codes = el.findall(".//g:VendorCostCode", ns)
+    if codes:
+        item.raw_data = item.raw_data or {}
+        item.raw_data["vendor_codes"] = [c.text for c in codes]
+
+doc = GAEBParser.parse("file.X83", post_parse_hook=extract_vendor_codes)
+```
+
+### Collecting unknown XML elements
+
+Set `collect_raw_data=True` to automatically populate `item.raw_data` with child elements not consumed by the built-in parser:
+
+```python
+doc = GAEBParser.parse("file.X83", collect_raw_data=True)
+for item in doc.iter_items():
+    if item.raw_data:
+        print(f"{item.oz}: {item.raw_data}")
+```
+
+See the [Extensibility Guide](extensibility.md) for more extension points.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - Custom & Vendor Tags: guides/custom-tags.md
     - Writing & Export: guides/writing.md
     - Caching: guides/caching.md
+    - Extensibility: guides/extensibility.md
   - API Reference:
     - reference/index.md
     - GAEBParser: reference/parser.md

--- a/pygaeb/__init__.py
+++ b/pygaeb/__init__.py
@@ -12,7 +12,7 @@ Quick start:
 
 from __future__ import annotations
 
-__version__ = "1.5.0"
+__version__ = "1.7.0"
 
 from pygaeb.exceptions import (
     ClassificationBackendError,
@@ -50,8 +50,13 @@ def __getattr__(name: str) -> object:
         "PyGAEBSettings": ("pygaeb.config", "PyGAEBSettings"),
         "configure": ("pygaeb.config", "configure"),
         "get_settings": ("pygaeb.config", "get_settings"),
+        "reset_settings": ("pygaeb.config", "reset_settings"),
         # Validation
         "CrossPhaseValidator": ("pygaeb.validation.cross_phase_validator", "CrossPhaseValidator"),
+        "register_validator": ("pygaeb.validation", "register_validator"),
+        "clear_validators": ("pygaeb.validation", "clear_validators"),
+        # Prompt registration
+        "register_prompt": ("pygaeb.classifier.prompt_templates", "register_prompt"),
         # Models (advanced — most users access via doc.award.boq, not direct import)
         "AwardInfo": ("pygaeb.models.document", "AwardInfo"),
         "GAEBInfo": ("pygaeb.models.document", "GAEBInfo"),
@@ -218,6 +223,10 @@ __all__ = [
     "ValidationResult",
     "ValidationSeverity",
     "__version__",
+    "clear_validators",
     "configure",
     "get_settings",
+    "register_prompt",
+    "register_validator",
+    "reset_settings",
 ]

--- a/pygaeb/cache.py
+++ b/pygaeb/cache.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import sqlite3
+from collections import OrderedDict
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -53,16 +54,28 @@ class CacheBackend(Protocol):
 
 
 class InMemoryCache:
-    """Default cache — plain dict, zero disk I/O, lives only for the session."""
+    """Default cache — LRU-bounded ``OrderedDict``, zero disk I/O.
 
-    def __init__(self) -> None:
-        self._store: dict[str, str] = {}
+    *maxsize* limits the number of entries.  When the limit is reached the
+    least-recently-used entry is evicted.  Pass ``0`` to disable the limit.
+    """
+
+    def __init__(self, maxsize: int = 10_000) -> None:
+        self._store: OrderedDict[str, str] = OrderedDict()
+        self._maxsize = maxsize
 
     def get(self, key: str) -> str | None:
-        return self._store.get(key)
+        value = self._store.get(key)
+        if value is not None:
+            self._store.move_to_end(key)
+        return value
 
     def put(self, key: str, value: str) -> None:
+        if key in self._store:
+            self._store.move_to_end(key)
         self._store[key] = value
+        if self._maxsize > 0 and len(self._store) > self._maxsize:
+            self._store.popitem(last=False)
 
     def delete(self, key: str) -> None:
         self._store.pop(key, None)
@@ -114,8 +127,11 @@ class SQLiteCache:
     def get(self, key: str) -> str | None:
         conn = self._get_conn()
         cursor = conn.execute("SELECT value FROM kv_cache WHERE key = ?", (key,))
-        row = cursor.fetchone()
-        return row[0] if row else None
+        try:
+            row = cursor.fetchone()
+            return row[0] if row else None
+        finally:
+            cursor.close()
 
     def put(self, key: str, value: str) -> None:
         conn = self._get_conn()
@@ -138,7 +154,10 @@ class SQLiteCache:
     def keys(self) -> list[str]:
         conn = self._get_conn()
         cursor = conn.execute("SELECT key FROM kv_cache")
-        return [row[0] for row in cursor.fetchall()]
+        try:
+            return [row[0] for row in cursor.fetchall()]
+        finally:
+            cursor.close()
 
     def close(self) -> None:
         if self._conn:
@@ -153,7 +172,14 @@ class SQLiteCache:
     def __exit__(self, *exc: object) -> None:
         self.close()
 
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self.close()
+
     def __len__(self) -> int:
         conn = self._get_conn()
         cursor = conn.execute("SELECT COUNT(*) FROM kv_cache")
-        return int(cursor.fetchone()[0])
+        try:
+            return int(cursor.fetchone()[0])
+        finally:
+            cursor.close()

--- a/pygaeb/classifier/batch_classifier.py
+++ b/pygaeb/classifier/batch_classifier.py
@@ -49,12 +49,16 @@ class LLMClassifier:
         cache: CacheBackend | None = None,
         concurrency: int | None = None,
         prompt_version: str = CURRENT_PROMPT_VERSION,
+        taxonomy: dict[str, dict[str, list[str]]] | None = None,
+        prompt_template: str | None = None,
     ) -> None:
         settings = get_settings()
         self.model = model or settings.default_model
         self.fallbacks = fallbacks or []
         self.concurrency = concurrency or settings.classifier_concurrency
         self.prompt_version = prompt_version
+        self.taxonomy = taxonomy
+        self.prompt_template = prompt_template
         self.cache = ClassificationCache(cache)
 
     async def enrich(
@@ -205,6 +209,8 @@ class LLMClassifier:
             unit=item.unit or "",
             prompt_version=self.prompt_version,
             fallbacks=self.fallbacks,
+            prompt_template=self.prompt_template,
+            taxonomy=self.taxonomy,
         )
 
     def _estimate_cost_usd(self, input_tokens: int, output_tokens: int) -> float:

--- a/pygaeb/classifier/llm_backend.py
+++ b/pygaeb/classifier/llm_backend.py
@@ -21,8 +21,13 @@ async def classify_single_item(
     prompt_version: str = "v1",
     max_retries: int = 2,
     fallbacks: list[str] | None = None,
+    prompt_template: str | None = None,
+    taxonomy: dict[str, dict[str, list[str]]] | None = None,
 ) -> ClassificationResult:
     """Classify a single construction item using LiteLLM + instructor.
+
+    *prompt_template* overrides the prompt for this call.
+    *taxonomy* appends allowed-trade information to the prompt.
 
     Returns a validated ClassificationResult — guaranteed by instructor.
     """
@@ -35,7 +40,14 @@ async def classify_single_item(
         ) from err
 
     client = instructor.from_litellm(litellm.acompletion)
-    prompt = get_prompt(prompt_version)
+    prompt = prompt_template if prompt_template is not None else get_prompt(prompt_version)
+
+    if taxonomy is not None:
+        taxonomy_lines = ["\nAllowed taxonomy:"]
+        for trade, elements in taxonomy.items():
+            for elem, subs in elements.items():
+                taxonomy_lines.append(f"  {trade} > {elem}: {', '.join(subs)}")
+        prompt = prompt + "\n".join(taxonomy_lines)
 
     user_message = (
         f"Hierarchy: {hierarchy_path}\n"

--- a/pygaeb/classifier/prompt_templates.py
+++ b/pygaeb/classifier/prompt_templates.py
@@ -41,10 +41,24 @@ CLASSIFICATION_PROMPT_V1 = (
     "- Always prefer specificity — classify to the most specific sub_type you can determine"
 )
 
-PROMPTS = {
+PROMPTS: dict[str, str] = {
     "v1": CLASSIFICATION_PROMPT_V1,
 }
 
+_custom_prompts: dict[str, str] = {}
+
+
+def register_prompt(version: str, template: str) -> None:
+    """Register a reusable prompt template under the given version key.
+
+    Registered prompts take precedence over built-in prompts when
+    retrieved via :func:`get_prompt`.
+    """
+    _custom_prompts[version] = template
+
 
 def get_prompt(version: str = CURRENT_PROMPT_VERSION) -> str:
+    """Return the prompt for *version*, checking user-registered prompts first."""
+    if version in _custom_prompts:
+        return _custom_prompts[version]
     return PROMPTS.get(version, CLASSIFICATION_PROMPT_V1)

--- a/pygaeb/config.py
+++ b/pygaeb/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,9 +18,17 @@ class PyGAEBSettings(BaseSettings):
     log_level: str = "WARNING"
     large_file_threshold_mb: int = 50
     large_file_item_threshold: int = 10000
+    max_file_size_mb: int = 100
 
 
 _settings: PyGAEBSettings | None = None
+
+
+def _apply_log_level(level: str) -> None:
+    """Set the ``pygaeb`` logger to *level*."""
+    logging.getLogger("pygaeb").setLevel(
+        getattr(logging, level.upper(), logging.WARNING),
+    )
 
 
 def get_settings() -> PyGAEBSettings:
@@ -26,6 +36,7 @@ def get_settings() -> PyGAEBSettings:
     global _settings
     if _settings is None:
         _settings = PyGAEBSettings()
+        _apply_log_level(_settings.log_level)
     return _settings
 
 
@@ -36,6 +47,7 @@ def configure(
     log_level: str | None = None,
     large_file_threshold_mb: int | None = None,
     large_file_item_threshold: int | None = None,
+    max_file_size_mb: int | None = None,
 ) -> PyGAEBSettings:
     """Override settings for the current session. Only supplied values are changed."""
     global _settings
@@ -53,9 +65,12 @@ def configure(
         overrides["large_file_threshold_mb"] = large_file_threshold_mb
     if large_file_item_threshold is not None:
         overrides["large_file_item_threshold"] = large_file_item_threshold
+    if max_file_size_mb is not None:
+        overrides["max_file_size_mb"] = max_file_size_mb
     merged = current.model_dump()
     merged.update(overrides)
     _settings = PyGAEBSettings(**merged)
+    _apply_log_level(_settings.log_level)
     return _settings
 
 

--- a/pygaeb/detector/version_detector.py
+++ b/pygaeb/detector/version_detector.py
@@ -11,6 +11,7 @@ from lxml import etree
 
 from pygaeb.detector.format_detector import FormatFamily, ParserTrack, detect_format
 from pygaeb.models.enums import ExchangePhase, SourceVersion
+from pygaeb.parser._xml_safety import safe_iterparse
 
 logger = logging.getLogger("pygaeb.detector")
 
@@ -102,7 +103,7 @@ def _detect_xml_version(path: Path, text: str | None = None) -> ParseRoute:
     try:
         raw = text.encode("utf-8") if text is not None else path.read_bytes()
 
-        for _event, elem in etree.iterparse(
+        for _event, elem in safe_iterparse(
             source=_bytes_io(raw),
             events=("start",),
         ):

--- a/pygaeb/models/boq.py
+++ b/pygaeb/models/boq.py
@@ -98,9 +98,11 @@ class BoQCtgy(BaseModel):
 
     def iter_items(self) -> Iterator[Item]:
         """Iterate all items in this category and its subcategories."""
-        yield from self.items
-        for subcat in self.subcategories:
-            yield from subcat.iter_items()
+        stack: list[BoQCtgy] = [self]
+        while stack:
+            current = stack.pop()
+            yield from current.items
+            stack.extend(reversed(current.subcategories))
 
     @property
     def subtotal(self) -> Decimal:
@@ -172,7 +174,12 @@ class BoQ(BaseModel):
                 yield from _walk_ctgy(ctgy, 1)
 
 
+_MAX_HIERARCHY_DEPTH = 50
+
+
 def _walk_ctgy(ctgy: BoQCtgy, depth: int) -> Iterator[tuple[int, str, BoQCtgy | None]]:
+    if depth > _MAX_HIERARCHY_DEPTH:
+        return
     yield (depth, ctgy.label, ctgy)
     for sub in ctgy.subcategories:
         yield from _walk_ctgy(sub, depth + 1)

--- a/pygaeb/models/cost.py
+++ b/pygaeb/models/cost.py
@@ -162,9 +162,11 @@ class CostElement(BaseModel):
 
     def iter_cost_elements(self) -> Iterator[CostElement]:
         """Yield this element and all descendants (depth-first)."""
-        yield self
-        for child in self.children:
-            yield from child.iter_cost_elements()
+        stack: list[CostElement] = [self]
+        while stack:
+            current = stack.pop()
+            yield current
+            stack.extend(reversed(current.children))
 
     @property
     def display_price(self) -> Decimal | None:
@@ -302,9 +304,14 @@ class ElementalCosting(BaseModel):
         return f"ElementalCosting(dp={self.dp!r}, items={count})"
 
 
+_MAX_HIERARCHY_DEPTH = 50
+
+
 def _walk_ec_ctgy(
     ctgy: ECCtgy, depth: int,
 ) -> Iterator[tuple[int, str, ECCtgy | None]]:
+    if depth > _MAX_HIERARCHY_DEPTH:
+        return
     label = ctgy.description or ctgy.ele_no
     yield (depth, label, ctgy)
     if ctgy.body is not None:

--- a/pygaeb/models/document.py
+++ b/pygaeb/models/document.py
@@ -212,6 +212,90 @@ class GAEBDocument(BaseModel):
         return item_count / 1024 + attach_bytes / (1024 * 1024)
 
     # ------------------------------------------------------------------
+    # Memory management
+    # ------------------------------------------------------------------
+
+    def discard_xml(self) -> None:
+        """Release the retained lxml tree and all ``source_element`` references.
+
+        Call this after you are done with :meth:`xpath` and
+        ``source_element`` access to free the underlying C-level memory
+        held by lxml.
+        """
+        self.xml_root = None
+        self.gaeb_info.source_element = None
+        self.award.source_element = None
+
+        if self.order is not None:
+            self.order.source_element = None
+            for oi in self.order.items:
+                oi.source_element = None
+
+        if self.elemental_costing is not None:
+            self.elemental_costing.source_element = None
+            self._discard_ec_elements(self.elemental_costing.body)
+
+        if self.qty_determination is not None:
+            self._discard_qty_elements(self.qty_determination.boq)
+
+        for lot in self.award.boq.lots:
+            for ctgy in lot.body.categories:
+                self._discard_boq_ctgy_elements(ctgy)
+
+    @staticmethod
+    def _discard_boq_ctgy_elements(ctgy: Any) -> None:
+        stack = [ctgy]
+        while stack:
+            c = stack.pop()
+            if hasattr(c, "source_element"):
+                c.source_element = None
+            for item in getattr(c, "items", []):
+                if hasattr(item, "source_element"):
+                    item.source_element = None
+            stack.extend(getattr(c, "subcategories", []))
+
+    @staticmethod
+    def _discard_ec_elements(body: Any) -> None:
+        for ce in getattr(body, "cost_elements", []):
+            stack_ce: list[Any] = [ce]
+            while stack_ce:
+                el = stack_ce.pop()
+                el.source_element = None
+                stack_ce.extend(getattr(el, "children", []))
+        for dim in getattr(body, "dimension_elements", []):
+            if hasattr(dim, "source_element"):
+                dim.source_element = None
+        for cat in getattr(body, "category_elements", []):
+            if hasattr(cat, "source_element"):
+                cat.source_element = None
+        for sub in getattr(body, "categories", []):
+            if hasattr(sub, "source_element"):
+                sub.source_element = None
+            if sub.body is not None:
+                GAEBDocument._discard_ec_elements(sub.body)
+
+    @staticmethod
+    def _discard_qty_elements(boq: Any) -> None:
+        if hasattr(boq, "source_element"):
+            boq.source_element = None
+        body = getattr(boq, "body", None)
+        stack = list(getattr(body, "categories", []) if body else [])
+        while stack:
+            c = stack.pop()
+            if hasattr(c, "source_element"):
+                c.source_element = None
+            for qi in getattr(c, "items", []):
+                if hasattr(qi, "source_element"):
+                    qi.source_element = None
+                for di in getattr(qi, "determ_items", []):
+                    if hasattr(di, "source_element"):
+                        di.source_element = None
+                    tr = getattr(di, "takeoff_row", None)
+                    if tr is not None and hasattr(tr, "source_element"):
+                        tr.source_element = None
+            stack.extend(getattr(c, "subcategories", []))
+
+    # ------------------------------------------------------------------
     # Validation helpers
     # ------------------------------------------------------------------
 

--- a/pygaeb/models/quantity.py
+++ b/pygaeb/models/quantity.py
@@ -115,9 +115,11 @@ class QtyBoQCtgy(BaseModel):
 
     def iter_items(self) -> Iterator[QtyItem]:
         """Iterate all items in this category and its subcategories."""
-        yield from self.items
-        for subcat in self.subcategories:
-            yield from subcat.iter_items()
+        stack: list[QtyBoQCtgy] = [self]
+        while stack:
+            current = stack.pop()
+            yield from current.items
+            stack.extend(reversed(current.subcategories))
 
 
 class QtyBoQBody(BaseModel):
@@ -210,9 +212,14 @@ class QtyDetermination(BaseModel):
         return self.boq.iter_hierarchy()
 
 
+_MAX_HIERARCHY_DEPTH = 50
+
+
 def _walk_qty_ctgy(
     ctgy: QtyBoQCtgy, depth: int,
 ) -> Iterator[tuple[int, str, QtyBoQCtgy | None]]:
+    if depth > _MAX_HIERARCHY_DEPTH:
+        return
     yield (depth, ctgy.rno, ctgy)
     for sub in ctgy.subcategories:
         yield from _walk_qty_ctgy(sub, depth + 1)

--- a/pygaeb/parser/_xml_safety.py
+++ b/pygaeb/parser/_xml_safety.py
@@ -1,0 +1,41 @@
+"""Hardened lxml parser constants — single source of truth for XXE prevention."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lxml import etree
+
+SAFE_PARSER: etree.XMLParser = etree.XMLParser(
+    resolve_entities=False,
+    no_network=True,
+    huge_tree=False,
+    dtd_validation=False,
+    remove_comments=False,
+)
+
+SAFE_RECOVER_PARSER: etree.XMLParser = etree.XMLParser(
+    resolve_entities=False,
+    no_network=True,
+    huge_tree=False,
+    recover=True,
+    encoding="utf-8",
+)
+
+
+def safe_iterparse(
+    source: Any,
+    events: tuple[str, ...] = ("start",),
+) -> Any:
+    """Wrapper around ``etree.iterparse`` with XXE protections.
+
+    ``lxml.etree.iterparse`` does not accept a ``parser`` argument;
+    instead, security-relevant settings are passed as keyword args.
+    """
+    return etree.iterparse(
+        source,
+        events=events,
+        resolve_entities=False,
+        no_network=True,
+        huge_tree=False,
+    )

--- a/pygaeb/parser/gaeb_parser.py
+++ b/pygaeb/parser/gaeb_parser.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from pygaeb.config import get_settings
 from pygaeb.detector.encoding_repair import repair_encoding
@@ -13,6 +15,7 @@ from pygaeb.detector.version_detector import ParseRoute, detect_version
 from pygaeb.exceptions import GAEBParseError, GAEBValidationError
 from pygaeb.models.document import GAEBDocument
 from pygaeb.models.enums import ExchangePhase, SourceVersion, ValidationMode, ValidationSeverity
+from pygaeb.models.item import ValidationResult
 
 logger = logging.getLogger("pygaeb.parser")
 
@@ -33,19 +36,44 @@ class GAEBParser:
         validation: ValidationMode = ValidationMode.LENIENT,
         xsd_dir: str | None = None,
         keep_xml: bool = False,
+        max_file_size: int | None = None,
+        post_parse_hook: Callable[[Any, Any], None] | None = None,
+        collect_raw_data: bool = False,
+        extra_validators: list[Callable[[GAEBDocument], list[ValidationResult]]] | None = None,
     ) -> GAEBDocument:
         """Parse a GAEB file from disk and return a unified GAEBDocument.
 
         Set *keep_xml* to ``True`` to retain raw lxml elements on every
         model (``item.source_element``) and enable ``doc.xpath()``.
+
+        *max_file_size* overrides the configured ``max_file_size_mb``
+        limit (in bytes).  Pass ``0`` to disable the check.
+
+        *post_parse_hook* is called with ``(item, source_element)`` for
+        every parsed item — useful for extracting vendor-specific XML
+        elements into ``item.raw_data``.
+
+        *collect_raw_data* when ``True`` automatically populates
+        ``item.raw_data`` with any XML child elements not consumed by
+        the built-in parser.
+
+        *extra_validators* are per-call validation functions appended
+        after the built-in and globally-registered validators.
         """
         path = Path(path)
         if not path.exists():
             raise GAEBParseError(f"File not found: {path}")
 
+        _enforce_size_limit(path.stat().st_size, max_file_size)
+
         raw = path.read_bytes()
         route = detect_version(path)
-        return _parse_core(raw, route, path, validation, xsd_dir, keep_xml)
+        return _parse_core(
+            raw, route, path, validation, xsd_dir, keep_xml,
+            post_parse_hook=post_parse_hook,
+            collect_raw_data=collect_raw_data,
+            extra_validators=extra_validators,
+        )
 
     @staticmethod
     def parse_bytes(
@@ -54,11 +82,16 @@ class GAEBParser:
         validation: ValidationMode = ValidationMode.LENIENT,
         xsd_dir: str | None = None,
         keep_xml: bool = False,
+        max_file_size: int | None = None,
+        post_parse_hook: Callable[[Any, Any], None] | None = None,
+        collect_raw_data: bool = False,
+        extra_validators: list[Callable[[GAEBDocument], list[ValidationResult]]] | None = None,
     ) -> GAEBDocument:
         """Parse GAEB data from bytes (useful for web uploads, S3 streams, etc.).
 
         The filename hint is used for version/phase detection from the extension.
         """
+        _enforce_size_limit(len(data), max_file_size)
         hint_path = Path(filename)
         with tempfile.NamedTemporaryFile(suffix=hint_path.suffix, delete=False) as tmp:
             tmp.write(data)
@@ -67,6 +100,9 @@ class GAEBParser:
             route = detect_version(tmp_path)
             return _parse_core(
                 data, route, hint_path, validation, xsd_dir, keep_xml,
+                post_parse_hook=post_parse_hook,
+                collect_raw_data=collect_raw_data,
+                extra_validators=extra_validators,
             )
         finally:
             tmp_path.unlink(missing_ok=True)
@@ -78,6 +114,10 @@ class GAEBParser:
         validation: ValidationMode = ValidationMode.LENIENT,
         xsd_dir: str | None = None,
         keep_xml: bool = False,
+        max_file_size: int | None = None,
+        post_parse_hook: Callable[[Any, Any], None] | None = None,
+        collect_raw_data: bool = False,
+        extra_validators: list[Callable[[GAEBDocument], list[ValidationResult]]] | None = None,
     ) -> GAEBDocument:
         """Parse GAEB data from an XML string.
 
@@ -85,6 +125,30 @@ class GAEBParser:
         """
         return GAEBParser.parse_bytes(
             xml_text.encode("utf-8"), filename, validation, xsd_dir, keep_xml,
+            max_file_size,
+            post_parse_hook=post_parse_hook,
+            collect_raw_data=collect_raw_data,
+            extra_validators=extra_validators,
+        )
+
+
+def _enforce_size_limit(size_bytes: int, explicit_limit: int | None) -> None:
+    """Raise ``GAEBParseError`` if *size_bytes* exceeds the configured maximum.
+
+    *explicit_limit* (in bytes) overrides the global setting when provided.
+    Pass ``0`` to disable the check entirely.
+    """
+    if explicit_limit is not None:
+        limit = explicit_limit
+    else:
+        limit = get_settings().max_file_size_mb * 1024 * 1024
+    if limit > 0 and size_bytes > limit:
+        mb = size_bytes / (1024 * 1024)
+        limit_mb = limit / (1024 * 1024)
+        raise GAEBParseError(
+            f"File size ({mb:.1f} MB) exceeds the maximum allowed "
+            f"({limit_mb:.0f} MB). Increase max_file_size_mb in settings or "
+            f"pass max_file_size=0 to disable."
         )
 
 
@@ -95,6 +159,10 @@ def _parse_core(
     validation: ValidationMode,
     xsd_dir: str | None,
     keep_xml: bool = False,
+    *,
+    post_parse_hook: Callable[[Any, Any], None] | None = None,
+    collect_raw_data: bool = False,
+    extra_validators: list[Callable[[GAEBDocument], list[ValidationResult]]] | None = None,
 ) -> GAEBDocument:
     """Shared parsing pipeline for all entry points."""
     logger.debug(
@@ -106,11 +174,23 @@ def _parse_core(
         for w in route.warnings:
             logger.warning(w)
 
+    needs_xml_temporarily = (post_parse_hook is not None or collect_raw_data) and not keep_xml
+    effective_keep_xml = keep_xml or post_parse_hook is not None or collect_raw_data
+
     is_xml = route.format_family != FormatFamily.GAEB_90
     text, encoding_info = repair_encoding(raw, is_xml=is_xml)
     route.encoding_info = encoding_info
 
-    doc = _dispatch_parser(route, source_path, text, keep_xml)
+    doc = _dispatch_parser(route, source_path, text, effective_keep_xml)
+
+    if collect_raw_data:
+        _collect_raw_data(doc)
+
+    if post_parse_hook is not None:
+        _run_post_parse_hook(doc, post_parse_hook)
+
+    if needs_xml_temporarily:
+        doc.discard_xml()
 
     if xsd_dir is None:
         xsd_dir = get_settings().xsd_dir
@@ -121,7 +201,7 @@ def _parse_core(
         doc.add_info("XSD validation skipped: no schema directory configured")
 
     from pygaeb.validation import run_validation
-    run_validation(doc, route)
+    run_validation(doc, route, extra_validators=extra_validators)
 
     if validation == ValidationMode.STRICT:
         errors = [
@@ -140,6 +220,34 @@ def _parse_core(
     )
 
     return doc
+
+
+def _run_post_parse_hook(
+    doc: GAEBDocument,
+    hook: Callable[[Any, Any], None],
+) -> None:
+    """Call *hook(item, source_element)* for every item that has a source_element."""
+    for item in doc.iter_items():
+        hook(item, getattr(item, "source_element", None))
+
+
+def _collect_raw_data(doc: GAEBDocument) -> None:
+    """Populate ``item.raw_data`` with child XML elements not consumed by the parser."""
+    from pygaeb.parser.xml_v3.base_v3_parser import KNOWN_ITEM_TAGS
+
+    for item in doc.iter_items():
+        el = getattr(item, "source_element", None)
+        if el is None:
+            continue
+        extras: dict[str, Any] = {}
+        for child in el:
+            tag = child.tag
+            if "}" in tag:
+                tag = tag.split("}", 1)[1]
+            if tag not in KNOWN_ITEM_TAGS:
+                extras[tag] = child.text
+        if extras:
+            item.raw_data = extras
 
 
 _TRADE_PHASES = frozenset({
@@ -228,10 +336,16 @@ def _run_xsd_validation(
         doc.add_info(f"XSD validation skipped: no .xsd files in {version_dir}")
         return
 
+    from pygaeb.parser._xml_safety import SAFE_PARSER
+
     try:
-        schema_doc = etree.parse(str(xsd_files[0]))
+        with xsd_files[0].open("rb") as xsd_fh:
+            schema_doc = etree.parse(xsd_fh, parser=SAFE_PARSER)
         schema = etree.XMLSchema(schema_doc)
-        xml_doc = etree.fromstring(text.encode("utf-8"))
+        if doc.xml_root is not None:
+            xml_doc = doc.xml_root
+        else:
+            xml_doc = etree.fromstring(text.encode("utf-8"), parser=SAFE_PARSER)
         if not schema.validate(xml_doc):
             for error in schema.error_log:  # type: ignore[attr-defined]
                 doc.add_warning(

--- a/pygaeb/parser/recovery.py
+++ b/pygaeb/parser/recovery.py
@@ -10,12 +10,12 @@ from lxml import etree
 from pygaeb.exceptions import GAEBParseError
 from pygaeb.models.enums import ValidationSeverity
 from pygaeb.models.item import ValidationResult
+from pygaeb.parser._xml_safety import SAFE_PARSER, SAFE_RECOVER_PARSER
 
 logger = logging.getLogger("pygaeb.parser")
 
 _NULL_BYTES_RE = re.compile(rb"[\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e-\x1f]")
 _BARE_AMP_RE = re.compile(rb"&(?!(?:amp|lt|gt|apos|quot|#\d+|#x[0-9a-fA-F]+);)")
-_UNCLOSED_TAG_RE = re.compile(rb"<(\w+)([^/>]*)(?<!/)>(?!.*?</\1>)", re.DOTALL)
 
 
 def parse_xml_safe(
@@ -31,7 +31,7 @@ def parse_xml_safe(
     raw = text.encode("utf-8")
 
     try:
-        root = etree.fromstring(raw)
+        root = etree.fromstring(raw, parser=SAFE_PARSER)
         return root, warnings
     except etree.XMLSyntaxError:
         pass
@@ -43,22 +43,24 @@ def parse_xml_safe(
             message="Applied byte-level sanitisation to repair malformed XML",
         ))
         try:
-            root = etree.fromstring(sanitised)
+            root = etree.fromstring(sanitised, parser=SAFE_PARSER)
             return root, warnings
         except etree.XMLSyntaxError:
             pass
 
     try:
-        parser = etree.XMLParser(recover=True, encoding="utf-8")
-        root = etree.fromstring(sanitised, parser=parser)
+        root = etree.fromstring(sanitised, parser=SAFE_RECOVER_PARSER)
         if root is None:
             raise GAEBParseError(
                 f"XML recovery produced empty tree: {source_file}",
-                errors=[str(e) for e in parser.error_log],
+                errors=[str(e) for e in SAFE_RECOVER_PARSER.error_log],
             )
         warnings.append(ValidationResult(
             severity=ValidationSeverity.WARNING,
-            message=f"Recovered from malformed XML ({len(parser.error_log)} errors)",
+            message=(
+                f"Recovered from malformed XML "
+                f"({len(SAFE_RECOVER_PARSER.error_log)} errors)"
+            ),
         ))
         return root, warnings
     except etree.XMLSyntaxError as e:

--- a/pygaeb/parser/xml_v3/base_v3_parser.py
+++ b/pygaeb/parser/xml_v3/base_v3_parser.py
@@ -38,6 +38,19 @@ from pygaeb.parser.xml_v3.richtext_parser import parse_plaintext, parse_richtext
 
 logger = logging.getLogger("pygaeb.parser")
 
+KNOWN_ITEM_TAGS: frozenset[str] = frozenset({
+    "ShortText", "Qty", "QU", "UP", "IT",
+    "LongText", "Description", "CompleteText", "OutlineText",
+    "QtySplit", "ItemTag", "GUID", "BIMRef", "CONo",
+    "CostApproach", "UPComp1", "UPComp2", "UPComp3",
+    "UPComp4", "UPComp5", "UPComp6", "DiscountPcnt", "VAT",
+    "CtlgAssign", "Attachment", "ATTImage", "ATTBinary",
+    "LumpSumItem", "GlobItem", "AlternativeItem", "AltItem",
+    "ContingencyItem", "EventualItem", "TextItem",
+    "SurchargeItem", "SupplementItem", "IndexItem",
+    "Itemlist", "Item",
+})
+
 
 class BaseV3Parser:
     """Shared parse logic for all DA XML 3.x versions."""

--- a/pygaeb/validation/__init__.py
+++ b/pygaeb/validation/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from pygaeb.detector.version_detector import ParseRoute
 from pygaeb.models.document import GAEBDocument
 from pygaeb.models.item import ValidationResult
@@ -11,9 +13,36 @@ from pygaeb.validation.numeric_validator import validate_numerics
 from pygaeb.validation.phase_validator import validate_phase
 from pygaeb.validation.structural_validator import validate_structure
 
+ValidatorFn = Callable[[GAEBDocument], list[ValidationResult]]
 
-def run_validation(doc: GAEBDocument, route: ParseRoute) -> list[ValidationResult]:
-    """Run all validation passes and append results to the document."""
+_custom_validators: list[ValidatorFn] = []
+
+
+def register_validator(fn: ValidatorFn) -> None:
+    """Register a custom validation rule that runs after built-in validators.
+
+    The callable receives a ``GAEBDocument`` and must return a
+    ``list[ValidationResult]``.  Results are appended to the document's
+    ``validation_results``.
+    """
+    _custom_validators.append(fn)
+
+
+def clear_validators() -> None:
+    """Remove all custom validators.  Useful in tests."""
+    _custom_validators.clear()
+
+
+def run_validation(
+    doc: GAEBDocument,
+    route: ParseRoute,
+    extra_validators: list[ValidatorFn] | None = None,
+) -> list[ValidationResult]:
+    """Run all validation passes and append results to the document.
+
+    *extra_validators* are per-call validators that run in addition to the
+    globally registered ones.
+    """
     results: list[ValidationResult] = []
 
     results.extend(validate_structure(doc))
@@ -21,12 +50,20 @@ def run_validation(doc: GAEBDocument, route: ParseRoute) -> list[ValidationResul
     results.extend(validate_numerics(doc))
     results.extend(validate_phase(doc, route))
 
+    for fn in _custom_validators:
+        results.extend(fn(doc))
+
+    for fn in extra_validators or []:
+        results.extend(fn(doc))
+
     doc.validation_results.extend(results)
     return results
 
 
 __all__ = [
     "CrossPhaseValidator",
+    "clear_validators",
+    "register_validator",
     "run_validation",
     "validate_items",
     "validate_numerics",

--- a/tests/test_extensibility.py
+++ b/tests/test_extensibility.py
@@ -1,0 +1,356 @@
+"""Tests for extensibility and custom configuration (v1.7.0).
+
+Covers:
+- register_validator / clear_validators — global and per-call
+- post_parse_hook — receives item + element, can populate raw_data
+- post_parse_hook auto-enables / discards XML when keep_xml=False
+- custom taxonomy= and prompt_template= on LLMClassifier
+- register_prompt() — custom prompt version is retrievable
+- collect_raw_data=True — unknown XML elements appear in item.raw_data
+- log_level application via configure()
+- reset_settings export accessibility
+"""
+
+from __future__ import annotations
+
+import logging
+from textwrap import dedent
+
+import pytest
+
+from pygaeb import GAEBParser
+from pygaeb.classifier.batch_classifier import LLMClassifier
+from pygaeb.classifier.prompt_templates import (
+    _custom_prompts,
+    get_prompt,
+    register_prompt,
+)
+from pygaeb.config import configure, get_settings, reset_settings
+from pygaeb.models.enums import ValidationSeverity
+from pygaeb.models.item import ValidationResult
+from pygaeb.validation import clear_validators, register_validator
+
+# ── XML Fixture ──────────────────────────────────────────────────────
+
+GAEB_WITH_VENDOR_EL = dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA86/3.3">
+      <GAEBInfo>
+        <Version>3.3</Version>
+        <ProgSystem>TestSuite</ProgSystem>
+      </GAEBInfo>
+      <Award>
+        <BoQ>
+          <BoQBody>
+            <BoQCtgy RNoPart="01" LblTx="Section 1">
+              <BoQBody>
+                <Itemlist>
+                  <Item RNoPart="001">
+                    <Qty>10.000</Qty>
+                    <QU>m2</QU>
+                    <UP>45.50</UP>
+                    <Description>
+                      <CompleteText>
+                        <OutlineText><OutlTxt><TextOutlTxt><p>Test item</p>\
+</TextOutlTxt></OutlTxt></OutlineText>
+                      </CompleteText>
+                    </Description>
+                    <VendorCostCode>VC-001</VendorCostCode>
+                    <CustomNote>Important</CustomNote>
+                  </Item>
+                </Itemlist>
+              </BoQBody>
+            </BoQCtgy>
+          </BoQBody>
+        </BoQ>
+      </Award>
+    </GAEB>""")
+
+GAEB_NO_UNIT = dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA86/3.3">
+      <GAEBInfo>
+        <Version>3.3</Version>
+        <ProgSystem>TestSuite</ProgSystem>
+      </GAEBInfo>
+      <Award>
+        <BoQ>
+          <BoQBody>
+            <BoQCtgy RNoPart="01" LblTx="Section 1">
+              <BoQBody>
+                <Itemlist>
+                  <Item RNoPart="001">
+                    <Qty>5.000</Qty>
+                    <UP>10.00</UP>
+                    <Description>
+                      <CompleteText>
+                        <OutlineText><OutlTxt><TextOutlTxt><p>No unit item</p>\
+</TextOutlTxt></OutlTxt></OutlineText>
+                      </CompleteText>
+                    </Description>
+                  </Item>
+                </Itemlist>
+              </BoQBody>
+            </BoQCtgy>
+          </BoQBody>
+        </BoQ>
+      </Award>
+    </GAEB>""")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Ensure validators and settings are reset between tests."""
+    clear_validators()
+    reset_settings()
+    _custom_prompts.clear()
+    yield
+    clear_validators()
+    reset_settings()
+    _custom_prompts.clear()
+
+
+# ── 1. Custom Validator Registry ─────────────────────────────────────
+
+class TestValidatorRegistry:
+    def test_register_and_run(self):
+        def require_unit(doc):
+            issues = []
+            for item in doc.iter_items():
+                if not item.unit:
+                    issues.append(
+                        ValidationResult(
+                            severity=ValidationSeverity.WARNING,
+                            message=f"{item.oz}: missing unit",
+                        )
+                    )
+            return issues
+
+        register_validator(require_unit)
+        doc = GAEBParser.parse_string(GAEB_NO_UNIT, filename="test.X83")
+
+        msgs = [r.message for r in doc.validation_results]
+        assert any("missing unit" in m for m in msgs)
+
+    def test_clear_validators(self):
+        def always_fail(doc):
+            return [ValidationResult(severity=ValidationSeverity.ERROR, message="boom")]
+
+        register_validator(always_fail)
+        clear_validators()
+
+        doc = GAEBParser.parse_string(GAEB_WITH_VENDOR_EL, filename="test.X83")
+        assert all("boom" not in r.message for r in doc.validation_results)
+
+    def test_extra_validators_per_call(self):
+        def check_qty(doc):
+            issues = []
+            for item in doc.iter_items():
+                if item.qty is None:
+                    issues.append(
+                        ValidationResult(
+                            severity=ValidationSeverity.WARNING,
+                            message=f"{item.oz}: no qty",
+                        )
+                    )
+            return issues
+
+        GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83", extra_validators=[check_qty],
+        )
+        from pygaeb.validation import _custom_validators
+        assert check_qty not in _custom_validators
+
+    def test_extra_validators_results_appear(self):
+        def always_warn(doc):
+            return [
+                ValidationResult(
+                    severity=ValidationSeverity.WARNING,
+                    message="extra-validator-ran",
+                )
+            ]
+
+        doc = GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83", extra_validators=[always_warn],
+        )
+        assert any("extra-validator-ran" in r.message for r in doc.validation_results)
+
+
+# ── 2. Post-Parse Hook ───────────────────────────────────────────────
+
+class TestPostParseHook:
+    def test_hook_receives_item_and_element(self):
+        received = []
+
+        def hook(item, el):
+            received.append((item.oz, el is not None))
+
+        GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83", post_parse_hook=hook,
+        )
+        assert len(received) >= 1
+        assert received[0] == ("001", True)
+
+    def test_hook_can_populate_raw_data(self):
+        def hook(item, el):
+            if el is None:
+                return
+            for child in el:
+                tag = child.tag
+                if "}" in tag:
+                    tag = tag.split("}", 1)[1]
+                if tag == "VendorCostCode":
+                    item.raw_data = item.raw_data or {}
+                    item.raw_data["vendor_code"] = child.text
+
+        doc = GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83", post_parse_hook=hook,
+        )
+        items = list(doc.iter_items())
+        assert items[0].raw_data is not None
+        assert items[0].raw_data["vendor_code"] == "VC-001"
+
+    def test_hook_auto_discards_xml_when_keep_xml_false(self):
+        def noop_hook(item, el):
+            pass
+
+        doc = GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83",
+            keep_xml=False, post_parse_hook=noop_hook,
+        )
+        # XML should have been discarded after hook ran
+        assert doc.xml_root is None
+        for item in doc.iter_items():
+            assert item.source_element is None
+
+    def test_hook_keeps_xml_when_keep_xml_true(self):
+        def noop_hook(item, el):
+            pass
+
+        doc = GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83",
+            keep_xml=True, post_parse_hook=noop_hook,
+        )
+        assert doc.xml_root is not None
+
+
+# ── 3. Custom Taxonomy & Prompt ──────────────────────────────────────
+
+class TestCustomTaxonomyPrompt:
+    def test_classifier_stores_taxonomy(self):
+        tax = {"Elec": {"Cable": ["Ladder"]}}
+        clf = LLMClassifier(taxonomy=tax)
+        assert clf.taxonomy is tax
+
+    def test_classifier_stores_prompt_template(self):
+        pt = "You are an MEP expert..."
+        clf = LLMClassifier(prompt_template=pt)
+        assert clf.prompt_template == pt
+
+    def test_default_taxonomy_is_none(self):
+        clf = LLMClassifier()
+        assert clf.taxonomy is None
+        assert clf.prompt_template is None
+
+    def test_register_prompt_and_retrieve(self):
+        register_prompt("custom-v1", "My custom prompt text")
+        assert get_prompt("custom-v1") == "My custom prompt text"
+
+    def test_registered_prompt_overrides_builtin(self):
+        register_prompt("v1", "Override of v1")
+        assert get_prompt("v1") == "Override of v1"
+
+    def test_unknown_version_falls_back_to_v1(self):
+        result = get_prompt("nonexistent")
+        assert "construction industry expert" in result
+
+
+# ── 4. Log Level Application ─────────────────────────────────────────
+
+class TestLogLevel:
+    def test_configure_debug_sets_logger(self):
+        configure(log_level="DEBUG")
+        pygaeb_logger = logging.getLogger("pygaeb")
+        assert pygaeb_logger.level == logging.DEBUG
+
+    def test_configure_error_sets_logger(self):
+        configure(log_level="ERROR")
+        pygaeb_logger = logging.getLogger("pygaeb")
+        assert pygaeb_logger.level == logging.ERROR
+
+    def test_default_level_is_warning(self):
+        reset_settings()
+        _ = get_settings()
+        pygaeb_logger = logging.getLogger("pygaeb")
+        assert pygaeb_logger.level == logging.WARNING
+
+    def test_configure_info_case_insensitive(self):
+        configure(log_level="info")
+        pygaeb_logger = logging.getLogger("pygaeb")
+        assert pygaeb_logger.level == logging.INFO
+
+
+# ── 5. Collect Raw Data ──────────────────────────────────────────────
+
+class TestCollectRawData:
+    def test_unknown_elements_in_raw_data(self):
+        doc = GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83", collect_raw_data=True,
+        )
+        items = list(doc.iter_items())
+        assert items[0].raw_data is not None
+        assert "VendorCostCode" in items[0].raw_data
+        assert items[0].raw_data["VendorCostCode"] == "VC-001"
+        assert "CustomNote" in items[0].raw_data
+        assert items[0].raw_data["CustomNote"] == "Important"
+
+    def test_known_elements_excluded(self):
+        doc = GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83", collect_raw_data=True,
+        )
+        items = list(doc.iter_items())
+        raw = items[0].raw_data or {}
+        # These are known tags and should NOT appear in raw_data
+        assert "Qty" not in raw
+        assert "QU" not in raw
+        assert "UP" not in raw
+        assert "Description" not in raw
+
+    def test_raw_data_none_when_disabled(self):
+        doc = GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83", collect_raw_data=False,
+        )
+        items = list(doc.iter_items())
+        assert items[0].raw_data is None
+
+    def test_collect_raw_data_discards_xml(self):
+        doc = GAEBParser.parse_string(
+            GAEB_WITH_VENDOR_EL, filename="test.X83",
+            collect_raw_data=True, keep_xml=False,
+        )
+        assert doc.xml_root is None
+        for item in doc.iter_items():
+            assert item.source_element is None
+
+
+# ── 6. reset_settings Export ─────────────────────────────────────────
+
+class TestResetSettings:
+    def test_importable_from_pygaeb(self):
+        import pygaeb
+        assert hasattr(pygaeb, "reset_settings")
+        assert callable(pygaeb.reset_settings)
+
+    def test_register_validator_importable(self):
+        import pygaeb
+        assert callable(pygaeb.register_validator)
+
+    def test_clear_validators_importable(self):
+        import pygaeb
+        assert callable(pygaeb.clear_validators)
+
+    def test_register_prompt_importable(self):
+        import pygaeb
+        assert callable(pygaeb.register_prompt)

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,516 @@
+"""Tests for security and memory hardening (v1.6.0).
+
+Covers:
+- XXE (XML External Entity) prevention
+- Billion Laughs entity expansion bomb prevention
+- File size limit enforcement
+- Recursion depth limits on hierarchy walkers
+- InMemoryCache LRU eviction
+- SQLiteCache resource cleanup (__del__, cursor close)
+- discard_xml() memory release
+- Round-trip regression after hardening changes
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from lxml import etree
+
+from pygaeb import GAEBParser, GAEBWriter, SourceVersion
+from pygaeb.cache import InMemoryCache, SQLiteCache
+from pygaeb.exceptions import GAEBParseError
+from pygaeb.models.boq import (
+    _MAX_HIERARCHY_DEPTH,
+    BoQ,
+    BoQBody,
+    BoQCtgy,
+    Lot,
+)
+from pygaeb.models.cost import (
+    _MAX_HIERARCHY_DEPTH as COST_MAX_DEPTH,
+)
+from pygaeb.models.cost import (
+    CostElement,
+    ECBody,
+    ECCtgy,
+    ElementalCosting,
+)
+from pygaeb.models.item import Item
+from pygaeb.models.quantity import (
+    _MAX_HIERARCHY_DEPTH as QTY_MAX_DEPTH,
+)
+from pygaeb.models.quantity import (
+    QtyBoQ,
+    QtyBoQBody,
+    QtyBoQCtgy,
+    QtyDetermination,
+)
+from pygaeb.parser._xml_safety import SAFE_PARSER, SAFE_RECOVER_PARSER, safe_iterparse
+
+# ── XML Fixtures ─────────────────────────────────────────────────────
+
+SIMPLE_GAEB = dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA86/3.3">
+      <GAEBInfo>
+        <Version>3.3</Version>
+        <ProgSystem>TestSuite</ProgSystem>
+      </GAEBInfo>
+      <Award>
+        <BoQ>
+          <BoQBody>
+            <BoQCtgy RNoPart="01" LblTx="Section 1">
+              <BoQBody>
+                <Itemlist>
+                  <Item RNoPart="001">
+                    <Qty>10.000</Qty>
+                    <QU>m2</QU>
+                    <UP>45.50</UP>
+                    <Description>
+                      <CompleteText>
+                        <OutlineText><OutlTxt><TextOutlTxt><p>Test item</p>\
+</TextOutlTxt></OutlTxt></OutlineText>
+                      </CompleteText>
+                    </Description>
+                  </Item>
+                </Itemlist>
+              </BoQBody>
+            </BoQCtgy>
+          </BoQBody>
+        </BoQ>
+      </Award>
+    </GAEB>""")
+
+XXE_ATTEMPT = dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <!DOCTYPE foo [
+      <!ENTITY xxe SYSTEM "file:///etc/passwd">
+    ]>
+    <GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA86/3.3">
+      <GAEBInfo>
+        <Version>3.3</Version>
+        <ProgSystem>&xxe;</ProgSystem>
+      </GAEBInfo>
+      <Award><BoQ><BoQBody>
+        <Itemlist><Item RNoPart="001"><Qty>1</Qty></Item></Itemlist>
+      </BoQBody></BoQ></Award>
+    </GAEB>""")
+
+BILLION_LAUGHS = dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <!DOCTYPE lolz [
+      <!ENTITY lol "lol">
+      <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+      <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+      <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+      <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+    ]>
+    <GAEB xmlns="http://www.gaeb.de/GAEB_DA_XML/DA86/3.3">
+      <GAEBInfo>
+        <Version>3.3</Version>
+        <ProgSystem>&lol5;</ProgSystem>
+      </GAEBInfo>
+      <Award><BoQ><BoQBody>
+        <Itemlist><Item RNoPart="001"><Qty>1</Qty></Item></Itemlist>
+      </BoQBody></BoQ></Award>
+    </GAEB>""")
+
+
+# ── 1. XXE Prevention ────────────────────────────────────────────────
+
+
+class TestXXEPrevention:
+    """Verify that external entity resolution is blocked."""
+
+    def test_xxe_entity_not_resolved(self) -> None:
+        doc = GAEBParser.parse_string(XXE_ATTEMPT, filename="test.X83")
+        prog = doc.gaeb_info.prog_system or ""
+        assert "root:" not in prog
+        assert "/bin/" not in prog
+
+    def test_billion_laughs_blocked(self) -> None:
+        doc = GAEBParser.parse_string(BILLION_LAUGHS, filename="test.X83")
+        prog = doc.gaeb_info.prog_system or ""
+        assert len(prog) < 1000
+
+    def test_safe_parser_blocks_entity_in_raw_xml(self) -> None:
+        xml_with_entity = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE foo [<!ENTITY xxe "INJECTED">]>'
+            b'<root>&xxe;</root>'
+        )
+        root = etree.fromstring(xml_with_entity, parser=SAFE_PARSER)
+        assert root.text != "INJECTED"
+
+    def test_safe_recover_parser_blocks_entity_in_raw_xml(self) -> None:
+        xml_with_entity = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE foo [<!ENTITY xxe "INJECTED">]>'
+            b'<root>&xxe;</root>'
+        )
+        root = etree.fromstring(xml_with_entity, parser=SAFE_RECOVER_PARSER)
+        assert root.text != "INJECTED"
+
+    def test_safe_parser_no_network(self) -> None:
+        raw = b'<?xml version="1.0"?><root/>'
+        root = etree.fromstring(raw, parser=SAFE_PARSER)
+        assert root.tag == "root"
+
+    def test_safe_iterparse_works(self) -> None:
+        import io
+        raw = b'<?xml version="1.0"?><root><child/></root>'
+        tags = []
+        for _event, elem in safe_iterparse(io.BytesIO(raw), events=("start",)):
+            tags.append(elem.tag)
+            elem.clear()
+        assert "root" in tags
+        assert "child" in tags
+
+
+# ── 2. File Size Guard ───────────────────────────────────────────────
+
+
+class TestFileSizeGuard:
+    """Verify oversized files are rejected before parsing."""
+
+    def test_parse_bytes_rejects_oversized(self) -> None:
+        data = b"x" * (1024 * 1024 + 1)
+        with pytest.raises(GAEBParseError, match="exceeds the maximum"):
+            GAEBParser.parse_bytes(data, max_file_size=1024 * 1024)
+
+    def test_parse_bytes_accepts_under_limit(self) -> None:
+        data = SIMPLE_GAEB.encode("utf-8")
+        doc = GAEBParser.parse_bytes(data, max_file_size=len(data) + 1024)
+        assert doc.item_count >= 1
+
+    def test_parse_string_rejects_oversized(self) -> None:
+        big_xml = "x" * 200
+        with pytest.raises(GAEBParseError, match="exceeds the maximum"):
+            GAEBParser.parse_string(big_xml, max_file_size=100)
+
+    def test_parse_file_rejects_oversized(self, tmp_path: Path) -> None:
+        f = tmp_path / "big.X83"
+        f.write_text(SIMPLE_GAEB)
+        with pytest.raises(GAEBParseError, match="exceeds the maximum"):
+            GAEBParser.parse(f, max_file_size=10)
+
+    def test_zero_limit_disables_check(self) -> None:
+        data = SIMPLE_GAEB.encode("utf-8")
+        doc = GAEBParser.parse_bytes(data, max_file_size=0)
+        assert doc.item_count >= 1
+
+
+# ── 3. Recursion Depth Limits ────────────────────────────────────────
+
+
+class TestRecursionDepthLimits:
+    """Verify deep hierarchies are handled without stack overflow."""
+
+    def test_max_depth_constant_exists(self) -> None:
+        assert _MAX_HIERARCHY_DEPTH == 50
+        assert COST_MAX_DEPTH == 50
+        assert QTY_MAX_DEPTH == 50
+
+    def test_deep_boq_hierarchy_stops_at_limit(self) -> None:
+        innermost = BoQCtgy(rno="deep", label="Deep")
+        current = innermost
+        for i in range(100):
+            parent = BoQCtgy(
+                rno=str(i), label=f"Level {i}",
+                subcategories=[current],
+            )
+            current = parent
+
+        items = list(current.iter_items())
+        assert items == []
+
+        hierarchy = list(
+            BoQ(
+                lots=[Lot(body=BoQBody(categories=[current]))],
+            ).iter_hierarchy()
+        )
+        assert len(hierarchy) <= _MAX_HIERARCHY_DEPTH + 2
+
+    def test_deep_cost_hierarchy_stops_at_limit(self) -> None:
+        innermost = ECCtgy(ele_no="deep", description="Deep")
+        current = innermost
+        for i in range(100):
+            parent = ECCtgy(
+                ele_no=str(i),
+                description=f"Level {i}",
+                body=ECBody(categories=[current]),
+            )
+            current = parent
+
+        ec = ElementalCosting(body=ECBody(categories=[current]))
+        hierarchy = list(ec.iter_hierarchy())
+        assert len(hierarchy) <= COST_MAX_DEPTH + 2
+
+    def test_deep_qty_hierarchy_stops_at_limit(self) -> None:
+        innermost = QtyBoQCtgy(rno="deep")
+        current = innermost
+        for i in range(100):
+            parent = QtyBoQCtgy(
+                rno=str(i),
+                subcategories=[current],
+            )
+            current = parent
+
+        qd = QtyDetermination(boq=QtyBoQ(body=QtyBoQBody(categories=[current])))
+        hierarchy = list(qd.iter_hierarchy())
+        assert len(hierarchy) <= QTY_MAX_DEPTH + 2
+
+    def test_iterative_iter_items_handles_deep_boq(self) -> None:
+        innermost = BoQCtgy(
+            rno="leaf", label="Leaf",
+            items=[Item(oz="01.001", short_text="deep item")],
+        )
+        current = innermost
+        for i in range(200):
+            current = BoQCtgy(
+                rno=str(i), label=f"L{i}",
+                subcategories=[current],
+            )
+        items = list(current.iter_items())
+        assert len(items) == 1
+        assert items[0].oz == "01.001"
+
+    def test_iterative_cost_element_iteration(self) -> None:
+        innermost = CostElement(ele_no="leaf", short_text="deep cost")
+        current = innermost
+        for _ in range(200):
+            current = CostElement(
+                ele_no="parent", short_text="wrap",
+                children=[current],
+            )
+        elements = list(current.iter_cost_elements())
+        assert len(elements) == 201
+        assert elements[-1].ele_no == "leaf"
+
+
+# ── 4. InMemoryCache LRU Eviction ───────────────────────────────────
+
+
+class TestInMemoryCacheLRU:
+    """Verify LRU eviction and bounded size."""
+
+    def test_default_maxsize(self) -> None:
+        cache = InMemoryCache()
+        assert cache._maxsize == 10_000
+
+    def test_custom_maxsize(self) -> None:
+        cache = InMemoryCache(maxsize=5)
+        assert cache._maxsize == 5
+
+    def test_evicts_oldest_when_full(self) -> None:
+        cache = InMemoryCache(maxsize=3)
+        cache.put("a", "1")
+        cache.put("b", "2")
+        cache.put("c", "3")
+        cache.put("d", "4")
+
+        assert cache.get("a") is None
+        assert cache.get("b") == "2"
+        assert cache.get("d") == "4"
+        assert len(cache) == 3
+
+    def test_get_refreshes_lru_order(self) -> None:
+        cache = InMemoryCache(maxsize=3)
+        cache.put("a", "1")
+        cache.put("b", "2")
+        cache.put("c", "3")
+
+        cache.get("a")
+        cache.put("d", "4")
+
+        assert cache.get("a") == "1"
+        assert cache.get("b") is None
+
+    def test_put_existing_key_refreshes_order(self) -> None:
+        cache = InMemoryCache(maxsize=3)
+        cache.put("a", "1")
+        cache.put("b", "2")
+        cache.put("c", "3")
+
+        cache.put("a", "updated")
+        cache.put("d", "4")
+
+        assert cache.get("a") == "updated"
+        assert cache.get("b") is None
+
+    def test_zero_maxsize_disables_limit(self) -> None:
+        cache = InMemoryCache(maxsize=0)
+        for i in range(100):
+            cache.put(str(i), str(i))
+        assert len(cache) == 100
+
+    def test_clear_empties_cache(self) -> None:
+        cache = InMemoryCache(maxsize=5)
+        for i in range(5):
+            cache.put(str(i), str(i))
+        cache.clear()
+        assert len(cache) == 0
+
+    def test_delete_removes_entry(self) -> None:
+        cache = InMemoryCache(maxsize=5)
+        cache.put("a", "1")
+        cache.delete("a")
+        assert cache.get("a") is None
+
+
+# ── 5. SQLiteCache Cleanup ───────────────────────────────────────────
+
+
+class TestSQLiteCacheCleanup:
+    """Verify SQLiteCache properly manages resources."""
+
+    def test_context_manager_closes_connection(self, tmp_path: Path) -> None:
+        with SQLiteCache(str(tmp_path / "cache")) as cache:
+            cache.put("k", "v")
+            assert cache.get("k") == "v"
+        assert cache._conn is None
+
+    def test_del_closes_connection(self, tmp_path: Path) -> None:
+        cache = SQLiteCache(str(tmp_path / "cache"))
+        cache.put("k", "v")
+        assert cache._conn is not None
+        cache.__del__()
+        assert cache._conn is None
+
+    def test_double_close_is_safe(self, tmp_path: Path) -> None:
+        cache = SQLiteCache(str(tmp_path / "cache"))
+        cache.put("k", "v")
+        cache.close()
+        cache.close()
+        assert cache._conn is None
+
+    def test_cursor_closed_after_get(self, tmp_path: Path) -> None:
+        with SQLiteCache(str(tmp_path / "cache")) as cache:
+            cache.put("k", "v")
+            result = cache.get("k")
+            assert result == "v"
+
+    def test_cursor_closed_after_keys(self, tmp_path: Path) -> None:
+        with SQLiteCache(str(tmp_path / "cache")) as cache:
+            cache.put("a", "1")
+            cache.put("b", "2")
+            keys = cache.keys()
+            assert set(keys) == {"a", "b"}
+
+    def test_cursor_closed_after_len(self, tmp_path: Path) -> None:
+        with SQLiteCache(str(tmp_path / "cache")) as cache:
+            cache.put("a", "1")
+            cache.put("b", "2")
+            assert len(cache) == 2
+
+
+# ── 6. discard_xml() ────────────────────────────────────────────────
+
+
+class TestDiscardXml:
+    """Verify discard_xml() releases all lxml references."""
+
+    def test_discard_clears_xml_root(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB, keep_xml=True)
+        assert doc.xml_root is not None
+        doc.discard_xml()
+        assert doc.xml_root is None
+
+    def test_discard_clears_source_elements(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB, keep_xml=True)
+        for item in doc.iter_items():
+            assert item.source_element is not None
+        doc.discard_xml()
+        for item in doc.iter_items():
+            assert item.source_element is None
+
+    def test_discard_clears_gaeb_info_element(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB, keep_xml=True)
+        doc.discard_xml()
+        assert doc.gaeb_info.source_element is None
+
+    def test_discard_clears_award_element(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB, keep_xml=True)
+        doc.discard_xml()
+        assert doc.award.source_element is None
+
+    def test_discard_clears_boqctgy_elements(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB, keep_xml=True)
+        doc.discard_xml()
+        for lot in doc.award.boq.lots:
+            for ctgy in lot.body.categories:
+                assert ctgy.source_element is None
+
+    def test_data_survives_discard(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB, keep_xml=True)
+        doc.discard_xml()
+        assert doc.item_count >= 1
+        items = list(doc.iter_items())
+        assert items[0].short_text == "Test item"
+        assert items[0].qty == Decimal("10.000")
+
+    def test_xpath_raises_after_discard(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB, keep_xml=True)
+        doc.discard_xml()
+        with pytest.raises(RuntimeError, match="keep_xml"):
+            doc.xpath("//g:Item")
+
+    def test_discard_on_non_keep_xml_is_noop(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB)
+        doc.discard_xml()
+        assert doc.item_count >= 1
+
+
+# ── 7. Round-Trip Regression ─────────────────────────────────────────
+
+
+class TestRoundTripRegression:
+    """Verify existing functionality still works after hardening."""
+
+    def test_parse_write_roundtrip(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB)
+        xml_bytes, _warnings = GAEBWriter.to_bytes(doc)
+        doc2 = GAEBParser.parse_bytes(xml_bytes)
+        assert doc2.item_count == doc.item_count
+        items1 = list(doc.iter_items())
+        items2 = list(doc2.iter_items())
+        assert items1[0].short_text == items2[0].short_text
+        assert items1[0].qty == items2[0].qty
+
+    def test_keep_xml_still_works(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB, keep_xml=True)
+        assert doc.xml_root is not None
+        results = doc.xpath("//g:Item")
+        assert len(results) >= 1
+
+    def test_version_detection_still_works(self) -> None:
+        doc = GAEBParser.parse_string(SIMPLE_GAEB)
+        assert doc.source_version == SourceVersion.DA_XML_33
+
+
+# ── 8. Safe Parser Module ───────────────────────────────────────────
+
+
+class TestSafeParserModule:
+    """Verify the _xml_safety module constants are properly configured."""
+
+    def test_safe_parser_is_xmlparser(self) -> None:
+        assert isinstance(SAFE_PARSER, etree.XMLParser)
+
+    def test_safe_recover_parser_is_xmlparser(self) -> None:
+        assert isinstance(SAFE_RECOVER_PARSER, etree.XMLParser)
+
+    def test_safe_parser_parses_valid_xml(self) -> None:
+        raw = b'<?xml version="1.0"?><root><child attr="val"/></root>'
+        root = etree.fromstring(raw, parser=SAFE_PARSER)
+        assert root.tag == "root"
+        assert root[0].tag == "child"
+
+    def test_safe_recover_parser_handles_malformed(self) -> None:
+        raw = b'<root><unclosed></root>'
+        root = etree.fromstring(raw, parser=SAFE_RECOVER_PARSER)
+        assert root is not None


### PR DESCRIPTION
Security (v1.6.0):
- Hardened XML parsers with XXE/Billion Laughs prevention
- File size guard (configurable, default 100 MB)
- Recursion depth limits on hierarchy walkers (cap 50)
- InMemoryCache LRU-bounded (maxsize=10,000)
- SQLiteCache resource cleanup (__del__, cursor close)
- Removed ReDoS-prone unused regex
- discard_xml() for explicit memory release Extensibility (v1.7.0):
- Custom validator registry (register_validator/clear_validators)
- Per-call extra_validators on GAEBParser.parse()
- Post-parse hook for vendor XML extraction
- collect_raw_data for unknown XML element collection
- Custom LLM taxonomy and prompt_template on LLMClassifier
- register_prompt() for reusable prompt versions
- log_level setting now applied to pygaeb logger
- New exports: register_validator, clear_validators, reset_settings, register_prompt Docs & tests:
- New extensibility guide, updated parsing/quickstart docs
- README rewritten for v1.7.0 feature coverage
- 72 new tests (test_security_hardening + test_extensibility)