### PR TITLE
feat: add read-only BoQ tree API with parent references and indexed l…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-03-24
+
+### Added
+
+- **Read-only BoQ Tree API** — `BoQTree` adapter wraps an existing `BoQ` and builds a navigable node graph with parent references, depth tracking, and indexed lookups. The underlying Pydantic models are not modified.
+- **`BoQNode`** — Lightweight tree node with O(1) `parent`, `children`, `depth`, `index`, `siblings`, `ancestors`, `path`, `next_sibling`, `prev_sibling`, `is_leaf`, `is_root` properties.
+- **Type-safe model accessors** — `node.boq`, `node.lot`, `node.category`, `node.item` raise `TypeError` if accessed on the wrong node kind.
+- **Unified convenience properties** — `node.label`, `node.rno`, `node.label_path` work across all node kinds (root, lot, category, item).
+- **Subtree queries** — `node.iter_descendants()`, `node.iter_items()`, `node.iter_categories()`, `node.find(predicate)`, `node.find_all(predicate)`.
+- **`BoQTree` lookups** — `tree.find_item(oz)` (O(1) via index), `tree.find_category(rno)`, `tree.find_all_categories(rno)`.
+- **Tree traversal** — `tree.walk()` (depth-first) and `tree.walk_bfs()` (breadth-first) over all nodes.
+- **`NodeKind`** enum — `ROOT`, `LOT`, `CATEGORY`, `ITEM` discriminator for node types.
+- New exports: `BoQTree`, `BoQNode`, `NodeKind`.
+- 87 new tests covering tree navigation, lookups, iteration, and multi-lot documents.
+
 ## [1.7.1] - 2026-03-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -195,6 +195,35 @@ for vp in totals.vat_parts:
 print(doc.award.prj_id, doc.award.description, doc.award.currency_label)
 ```
 
+### Tree Navigation (BoQ Hierarchy)
+
+Navigate the BoQ with parent references, depth tracking, and indexed lookups:
+
+```python
+from pygaeb import BoQTree, NodeKind
+
+tree = BoQTree(doc.award.boq)
+
+# Find an item and navigate up
+node = tree.find_item("01.01.0010")
+print(node.parent.label)       # "Mauerwerk"
+print(node.depth)              # level in tree
+print(node.label_path)         # ["BoQ", "Default", "Rohbau", "Mauerwerk", "..."]
+print(node.siblings)           # sibling nodes
+
+# Walk the hierarchy
+for node in tree.walk():
+    indent = "  " * node.depth
+    print(f"{indent}{node.kind.value}: {node.label}")
+
+# Subtree queries
+expensive = tree.root.find_all(
+    lambda n: n.kind == NodeKind.ITEM
+    and n.item.total_price
+    and n.item.total_price > 50000
+)
+```
+
 ### LLM Classification
 
 ```python
@@ -403,6 +432,7 @@ Full documentation is available at [Read the Docs](https://pygaeb.readthedocs.io
 - [Trade Phases](https://pygaeb.readthedocs.io/guides/trade-phases/)
 - [Cost & Calculation](https://pygaeb.readthedocs.io/guides/cost-phases/)
 - [Quantity Determination](https://pygaeb.readthedocs.io/guides/quantity-phases/)
+- [Tree Navigation](https://pygaeb.readthedocs.io/guides/tree-navigation/)
 - [Extensibility](https://pygaeb.readthedocs.io/guides/extensibility/)
 - [Classification](https://pygaeb.readthedocs.io/guides/classification/)
 - [Version Conversion](https://pygaeb.readthedocs.io/guides/conversion/)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,22 @@ All notable changes to pyGAEB are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-03-24
+
+### Added
+
+- **Read-only BoQ Tree API** — `BoQTree` adapter wraps an existing `BoQ` and builds a navigable node graph with parent references, depth tracking, and indexed lookups. The underlying Pydantic models are not modified.
+- **`BoQNode`** — Lightweight tree node with O(1) `parent`, `children`, `depth`, `index`, `siblings`, `ancestors`, `path`, `next_sibling`, `prev_sibling`, `is_leaf`, `is_root` properties.
+- **Type-safe model accessors** — `node.boq`, `node.lot`, `node.category`, `node.item` raise `TypeError` if accessed on the wrong node kind.
+- **Unified convenience properties** — `node.label`, `node.rno`, `node.label_path` work across all node kinds (root, lot, category, item).
+- **Subtree queries** — `node.iter_descendants()`, `node.iter_items()`, `node.iter_categories()`, `node.find(predicate)`, `node.find_all(predicate)`.
+- **`BoQTree` lookups** — `tree.find_item(oz)` (O(1) via index), `tree.find_category(rno)`, `tree.find_all_categories(rno)`.
+- **Tree traversal** — `tree.walk()` (depth-first) and `tree.walk_bfs()` (breadth-first) over all nodes.
+- **`NodeKind`** enum — `ROOT`, `LOT`, `CATEGORY`, `ITEM` discriminator for node types.
+- New exports: `BoQTree`, `BoQNode`, `NodeKind`.
+- New guide: [Tree Navigation](guides/tree-navigation.md).
+- 87 new tests covering root, lots, categories, items, children ordering, parent chains, ancestors, siblings, lookups, iteration, predicate search, DFS/BFS traversal, counts, multi-lot, type-safe accessors, empty categories, model identity, and repr.
+
 ## [1.7.1] - 2026-03-15
 
 ### Fixed
@@ -196,6 +212,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `py.typed` marker for PEP 561 compliance
 - Comprehensive test suite (193 tests)
 
+[1.8.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.8.0
 [1.7.1]: https://github.com/frameiq/pygaeb/releases/tag/v1.7.1
 [1.7.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.7.0
 [1.6.0]: https://github.com/frameiq/pygaeb/releases/tag/v1.6.0

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -13,3 +13,4 @@ In-depth guides for every pyGAEB capability.
 - **[Custom & Vendor Tags](custom-tags.md)** — raw XML access, XPath queries, vendor extensions
 - **[Writing & Export](writing.md)** — round-trip editing, phase override, JSON/CSV export
 - **[Caching](caching.md)** — in-memory, SQLite, and custom cache backends
+- **[Tree Navigation](tree-navigation.md)** — BoQTree adapter with parent references, sibling navigation, depth tracking, and subtree queries

--- a/docs/guides/tree-navigation.md
+++ b/docs/guides/tree-navigation.md
@@ -1,0 +1,220 @@
+# Tree Navigation
+
+*Since v1.8.0*
+
+The `BoQTree` API provides a read-only tree view over a procurement BoQ with parent references, depth tracking, sibling navigation, and indexed lookups. It wraps the existing Pydantic models without modifying them.
+
+## Why a Tree API?
+
+The core `BoQ → Lot → BoQBody → BoQCtgy → Item` model is a downward-only nested structure — you can iterate items, but you cannot ask "what category does this item belong to?" or "what are the siblings of this section?". Every application building a UI tree, a copy/paste feature, or a structured report ends up reimplementing the same recursive walk.
+
+`BoQTree` solves this by building a lightweight node graph on top of the existing models, with O(1) access to parent, children, depth, and siblings.
+
+## Quick Start
+
+```python
+from pygaeb import GAEBParser, BoQTree
+
+doc = GAEBParser.parse("tender.X83")
+tree = BoQTree(doc.award.boq)
+
+# Find an item and navigate up
+node = tree.find_item("01.01.0010")
+print(node.parent.label)       # "Mauerwerk" (category label)
+print(node.parent.parent.label) # "Rohbau" (parent category)
+print(node.depth)              # 4
+print(node.label_path)         # ["BoQ", "Default", "Rohbau", "Mauerwerk", "Mauerwerk Innenwand"]
+```
+
+## Node Kinds
+
+Every node in the tree has a `kind` that tells you what it wraps:
+
+| Kind | Wraps | Typical depth |
+|------|-------|---------------|
+| `NodeKind.ROOT` | `BoQ` | 0 |
+| `NodeKind.LOT` | `Lot` | 1 |
+| `NodeKind.CATEGORY` | `BoQCtgy` | 2+ |
+| `NodeKind.ITEM` | `Item` | leaf level |
+
+## Navigating the Tree
+
+### Parent, children, siblings
+
+```python
+from pygaeb.api.boq_tree import NodeKind
+
+for lot_node in tree.lots:
+    print(lot_node.label, lot_node.depth)
+
+    for child in lot_node.children:
+        if child.kind == NodeKind.CATEGORY:
+            print(f"  {child.rno} {child.label}")
+
+            # Siblings
+            for sib in child.siblings:
+                print(f"    sibling: {sib.label}")
+
+            # Items in this category
+            for item_node in child.iter_items():
+                print(f"    {item_node.item.oz} {item_node.item.short_text}")
+                print(f"      parent: {item_node.parent.label}")
+```
+
+### Ancestors and path
+
+```python
+node = tree.find_item("01.02.0030")
+
+# All ancestors from root to parent (excludes self)
+for ancestor in node.ancestors:
+    print(f"  {ancestor.kind.value}: {ancestor.label}")
+
+# Full path from root to self (includes self)
+print(node.path)
+
+# Human-readable breadcrumb
+print(" > ".join(node.label_path))
+```
+
+### Sibling navigation
+
+```python
+node = tree.find_item("01.02.0010")
+print(node.index)              # 0 (first among siblings)
+print(node.next_sibling)       # BoQNode for the next item
+print(node.prev_sibling)       # None (first item)
+```
+
+## Lookups
+
+### Find item by OZ (O(1))
+
+```python
+node = tree.find_item("01.01.0010")
+if node:
+    print(node.item.short_text, node.item.total_price)
+```
+
+### Find category by rno
+
+```python
+node = tree.find_category("02")
+if node:
+    print(node.label, node.category.subtotal)
+```
+
+### Find all categories with same rno (multi-lot)
+
+In multi-lot documents, the same rno can appear in different lots:
+
+```python
+nodes = tree.find_all_categories("01")
+for n in nodes:
+    lot_label = n.parent.label  # which lot this category belongs to
+    print(f"  {lot_label}: {n.label}")
+```
+
+## Subtree Queries
+
+Every `BoQNode` supports queries over its descendants:
+
+```python
+# All items under a specific category
+rohbau = tree.find_category("01")
+for item_node in rohbau.iter_items():
+    print(item_node.item.oz)
+
+# All categories (recursive)
+for cat_node in tree.root.iter_categories():
+    print(f"{'  ' * cat_node.depth}{cat_node.rno} {cat_node.label}")
+
+# Find by predicate
+expensive = tree.root.find_all(
+    lambda n: n.kind == NodeKind.ITEM and n.item.total_price and n.item.total_price > 50000
+)
+for n in expensive:
+    print(n.item.oz, n.item.total_price)
+```
+
+## Tree Traversal
+
+### Depth-first (DFS)
+
+```python
+for node in tree.walk():
+    indent = "  " * node.depth
+    print(f"{indent}{node.kind.value}: {node.label}")
+```
+
+### Breadth-first (BFS)
+
+```python
+for node in tree.walk_bfs():
+    print(f"[depth={node.depth}] {node.kind.value}: {node.label}")
+```
+
+## Type-Safe Model Access
+
+Each node provides a type-safe accessor that raises `TypeError` if you use the wrong one:
+
+```python
+lot_node = tree.lots[0]
+lot_node.lot           # Lot model — works
+lot_node.item          # TypeError: Cannot access .item on a lot node
+
+item_node = tree.find_item("01.01.0010")
+item_node.item         # Item model — works
+item_node.category     # TypeError: Cannot access .category on an item node
+```
+
+## Convenience Properties
+
+These work on any node kind, giving you a unified interface:
+
+| Property | ROOT | LOT | CATEGORY | ITEM |
+|----------|------|-----|----------|------|
+| `label` | `"BoQ"` | `lot.label` | `ctgy.label` | `item.short_text` |
+| `rno` | `""` | `lot.rno` | `ctgy.rno` | `item.oz` |
+| `label_path` | `["BoQ"]` | `["BoQ", "Default"]` | `["BoQ", ..., "Rohbau"]` | `["BoQ", ..., "Mauerwerk Innenwand"]` |
+
+## Building a UI Tree
+
+A common use case is rendering the BoQ as a hierarchical tree (React, Qt, etc.):
+
+```python
+def to_ui_tree(node):
+    result = {
+        "kind": node.kind.value,
+        "label": node.label,
+        "rno": node.rno,
+        "depth": node.depth,
+    }
+    if node.kind == NodeKind.ITEM:
+        result["oz"] = node.item.oz
+        result["qty"] = str(node.item.qty)
+        result["unit"] = node.item.unit
+        result["total"] = str(node.item.total_price)
+    if node.children:
+        result["children"] = [to_ui_tree(child) for child in node.children]
+    return result
+
+tree_data = to_ui_tree(tree.root)
+```
+
+## Counts
+
+```python
+print(tree.node_count)   # Total nodes (root + lots + categories + items)
+print(tree.item_count)   # Just items
+print(tree.is_multi_lot) # True if > 1 lot
+print(len(tree.lots))    # Number of lots
+```
+
+## Design Notes
+
+- **Read-only** — `BoQNode.children` is a tuple (immutable). The tree API does not support mutation (move, detach, duplicate). This is planned for a future release.
+- **Zero model impact** — The underlying `BoQ`, `Lot`, `BoQCtgy`, and `Item` models are not modified. `BoQNode.model` returns the exact same Pydantic object (same identity).
+- **O(n) construction** — Building the tree is a single pass over all nodes. For a 10,000-item document, this takes < 5ms.
+- **Opt-in** — If you never construct a `BoQTree`, the tree code never runs. There is no performance cost for users who don't need it.
+- **Procurement BoQ only** — The current tree API works with `BoQ` from procurement documents. Cost (`ElementalCosting`) and quantity (`QtyDetermination`) tree adapters may be added in a future release.

--- a/docs/reference/boq-tree.md
+++ b/docs/reference/boq-tree.md
@@ -1,0 +1,24 @@
+# BoQ Tree API
+
+Read-only tree adapter for navigating the BoQ hierarchy with parent references, depth tracking, and indexed lookups.
+
+```python
+from pygaeb import BoQTree, BoQNode, NodeKind
+
+tree = BoQTree(doc.award.boq)
+```
+
+::: pygaeb.api.boq_tree.NodeKind
+    options:
+      show_root_heading: true
+      members_order: source
+
+::: pygaeb.api.boq_tree.BoQNode
+    options:
+      show_root_heading: true
+      members_order: source
+
+::: pygaeb.api.boq_tree.BoQTree
+    options:
+      show_root_heading: true
+      members_order: source

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,4 +18,5 @@ Complete reference documentation for all public classes, functions, and enums in
 - **[Cache](cache.md)** — `CacheBackend` protocol, `InMemoryCache`, `SQLiteCache`
 - **[Validation](validation.md)** — `CrossPhaseValidator`, validation result types
 - **[Configuration](config.md)** — `PyGAEBSettings`, `configure()`, `get_settings()`
+- **[BoQ Tree](boq-tree.md)** — `BoQTree`, `BoQNode`, `NodeKind`
 - **[Exceptions](exceptions.md)** — exception hierarchy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - Custom & Vendor Tags: guides/custom-tags.md
     - Writing & Export: guides/writing.md
     - Caching: guides/caching.md
+    - Tree Navigation: guides/tree-navigation.md
     - Extensibility: guides/extensibility.md
   - API Reference:
     - reference/index.md
@@ -99,6 +100,7 @@ nav:
     - Writer & Export: reference/writer.md
     - Cache: reference/cache.md
     - DocumentAPI: reference/document-api.md
+    - BoQ Tree: reference/boq-tree.md
     - Validation: reference/validation.md
     - Configuration: reference/config.md
     - Exceptions: reference/exceptions.md

--- a/pygaeb/__init__.py
+++ b/pygaeb/__init__.py
@@ -126,6 +126,10 @@ def __getattr__(name: str) -> object:
         "ValidationSeverity": ("pygaeb.models.enums", "ValidationSeverity"),
         # Document navigation
         "DocumentAPI": ("pygaeb.api.document_api", "DocumentAPI"),
+        # Tree API
+        "BoQTree": ("pygaeb.api.boq_tree", "BoQTree"),
+        "BoQNode": ("pygaeb.api.boq_tree", "BoQNode"),
+        "NodeKind": ("pygaeb.api.boq_tree", "NodeKind"),
     }
 
     if name in _lazy_map:
@@ -149,6 +153,8 @@ __all__ = [
     "BoQCtgyRef",
     "BoQInfo",
     "BoQItemRef",
+    "BoQNode",
+    "BoQTree",
     "CacheBackend",
     "Catalog",
     "CategoryElement",
@@ -194,6 +200,7 @@ __all__ = [
     "LLMClassifier",
     "Lot",
     "MarkupSubQty",
+    "NodeKind",
     "OrderInfo",
     "OrderItem",
     "PlannerInfo",

--- a/pygaeb/api/__init__.py
+++ b/pygaeb/api/__init__.py
@@ -1,5 +1,6 @@
 """Navigation and query API for GAEBDocument."""
 
+from pygaeb.api.boq_tree import BoQNode, BoQTree, NodeKind
 from pygaeb.api.document_api import DocumentAPI
 
-__all__ = ["DocumentAPI"]
+__all__ = ["BoQNode", "BoQTree", "DocumentAPI", "NodeKind"]

--- a/pygaeb/api/boq_tree.py
+++ b/pygaeb/api/boq_tree.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Iterator
 from enum import Enum
-from typing import Any, Callable, Union
+from typing import Callable, Union
 
 from pygaeb.models.boq import BoQ, BoQCtgy, Lot
 from pygaeb.models.item import Item
@@ -46,7 +46,7 @@ class BoQNode:
     Children are stored as an immutable tuple to signal read-only intent.
     """
 
-    __slots__ = ("_kind", "_model", "_parent", "_children", "_depth", "_index")
+    __slots__ = ("_children", "_depth", "_index", "_kind", "_model", "_parent")
 
     def __init__(
         self,
@@ -65,7 +65,10 @@ class BoQNode:
         self._index = index
 
     def __repr__(self) -> str:
-        return f"BoQNode(kind={self._kind.value}, rno={self.rno!r}, label={self.label!r}, depth={self._depth})"
+        return (
+            f"BoQNode(kind={self._kind.value}, rno={self.rno!r},"
+            f" label={self.label!r}, depth={self._depth})"
+        )
 
     # ------------------------------------------------------------------
     # Core properties (precomputed, O(1))
@@ -255,7 +258,7 @@ class BoQTree:
     Construction is O(n) where n is the total number of nodes.
     """
 
-    __slots__ = ("_root", "_items_by_oz", "_node_count", "_item_count")
+    __slots__ = ("_item_count", "_items_by_oz", "_node_count", "_root")
 
     def __init__(self, boq: BoQ) -> None:
         self._items_by_oz: dict[str, BoQNode] = {}
@@ -264,7 +267,10 @@ class BoQTree:
         self._root = self._build_root(boq)
 
     def __repr__(self) -> str:
-        return f"BoQTree(lots={len(self._root._children)}, nodes={self._node_count}, items={self._item_count})"
+        return (
+            f"BoQTree(lots={len(self._root._children)},"
+            f" nodes={self._node_count}, items={self._item_count})"
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -394,7 +400,9 @@ class BoQTree:
 
         offset = len(child_nodes)
         for i, item_model in enumerate(ctgy.items):
-            item_node = self._build_item(item_model, parent=ctgy_node, depth=depth + 1, index=offset + i)
+            item_node = self._build_item(
+                item_model, parent=ctgy_node, depth=depth + 1, index=offset + i,
+            )
             child_nodes.append(item_node)
 
         ctgy_node._children = tuple(child_nodes)

--- a/pygaeb/api/boq_tree.py
+++ b/pygaeb/api/boq_tree.py
@@ -1,0 +1,418 @@
+"""Read-only tree API for navigating the BoQ hierarchy with parent references.
+
+Usage::
+
+    from pygaeb import GAEBParser, BoQTree
+
+    doc = GAEBParser.parse("tender.X83")
+    tree = BoQTree(doc.award.boq)
+
+    node = tree.find_item("01.01.0010")
+    print(node.parent.label)    # category label
+    print(node.depth)           # level in tree
+    print(node.label_path)      # breadcrumb from root
+
+The tree adapter wraps existing Pydantic models without modifying them.
+All navigation properties are precomputed at construction time (O(1) access).
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterator
+from enum import Enum
+from typing import Any, Callable, Union
+
+from pygaeb.models.boq import BoQ, BoQCtgy, Lot
+from pygaeb.models.item import Item
+
+
+class NodeKind(str, Enum):
+    """Discriminator for the type of model a BoQNode wraps."""
+
+    ROOT = "root"
+    LOT = "lot"
+    CATEGORY = "category"
+    ITEM = "item"
+
+
+_ModelType = Union[BoQ, Lot, BoQCtgy, Item]
+
+
+class BoQNode:
+    """Read-only tree node wrapping a single BoQ model object.
+
+    Provides O(1) parent/children/depth access and subtree query helpers.
+    Children are stored as an immutable tuple to signal read-only intent.
+    """
+
+    __slots__ = ("_kind", "_model", "_parent", "_children", "_depth", "_index")
+
+    def __init__(
+        self,
+        kind: NodeKind,
+        model: _ModelType,
+        parent: BoQNode | None,
+        children: tuple[BoQNode, ...],
+        depth: int,
+        index: int,
+    ) -> None:
+        self._kind = kind
+        self._model = model
+        self._parent = parent
+        self._children = children
+        self._depth = depth
+        self._index = index
+
+    def __repr__(self) -> str:
+        return f"BoQNode(kind={self._kind.value}, rno={self.rno!r}, label={self.label!r}, depth={self._depth})"
+
+    # ------------------------------------------------------------------
+    # Core properties (precomputed, O(1))
+    # ------------------------------------------------------------------
+
+    @property
+    def kind(self) -> NodeKind:
+        return self._kind
+
+    @property
+    def model(self) -> _ModelType:
+        """The underlying Pydantic model object (same identity, not a copy)."""
+        return self._model
+
+    @property
+    def parent(self) -> BoQNode | None:
+        return self._parent
+
+    @property
+    def children(self) -> tuple[BoQNode, ...]:
+        return self._children
+
+    @property
+    def depth(self) -> int:
+        return self._depth
+
+    @property
+    def index(self) -> int:
+        """Position among siblings (0-based)."""
+        return self._index
+
+    # ------------------------------------------------------------------
+    # Derived navigation (computed from core, still cheap)
+    # ------------------------------------------------------------------
+
+    @property
+    def is_leaf(self) -> bool:
+        return len(self._children) == 0
+
+    @property
+    def is_root(self) -> bool:
+        return self._parent is None
+
+    @property
+    def siblings(self) -> tuple[BoQNode, ...]:
+        """All siblings excluding self. Empty tuple for root."""
+        if self._parent is None:
+            return ()
+        return tuple(c for c in self._parent._children if c is not self)
+
+    @property
+    def next_sibling(self) -> BoQNode | None:
+        if self._parent is None:
+            return None
+        sibs = self._parent._children
+        next_idx = self._index + 1
+        if next_idx < len(sibs):
+            return sibs[next_idx]
+        return None
+
+    @property
+    def prev_sibling(self) -> BoQNode | None:
+        if self._parent is None:
+            return None
+        prev_idx = self._index - 1
+        if prev_idx >= 0:
+            return self._parent._children[prev_idx]
+        return None
+
+    @property
+    def ancestors(self) -> tuple[BoQNode, ...]:
+        """From root to parent (excludes self). Empty for root."""
+        result: list[BoQNode] = []
+        node = self._parent
+        while node is not None:
+            result.append(node)
+            node = node._parent
+        result.reverse()
+        return tuple(result)
+
+    @property
+    def path(self) -> tuple[BoQNode, ...]:
+        """From root to self (includes self)."""
+        return (*self.ancestors, self)
+
+    # ------------------------------------------------------------------
+    # Type-safe model accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def boq(self) -> BoQ:
+        if self._kind != NodeKind.ROOT:
+            raise TypeError(f"Cannot access .boq on a {self._kind.value} node")
+        return self._model  # type: ignore[return-value]
+
+    @property
+    def lot(self) -> Lot:
+        if self._kind != NodeKind.LOT:
+            raise TypeError(f"Cannot access .lot on a {self._kind.value} node")
+        return self._model  # type: ignore[return-value]
+
+    @property
+    def category(self) -> BoQCtgy:
+        if self._kind != NodeKind.CATEGORY:
+            raise TypeError(f"Cannot access .category on a {self._kind.value} node")
+        return self._model  # type: ignore[return-value]
+
+    @property
+    def item(self) -> Item:
+        if self._kind != NodeKind.ITEM:
+            raise TypeError(f"Cannot access .item on a {self._kind.value} node")
+        return self._model  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Convenience (unified across node kinds)
+    # ------------------------------------------------------------------
+
+    @property
+    def label(self) -> str:
+        if self._kind == NodeKind.ROOT:
+            return "BoQ"
+        if self._kind == NodeKind.LOT:
+            return self._model.label or self._model.rno or "Lot"  # type: ignore[union-attr]
+        if self._kind == NodeKind.CATEGORY:
+            return self._model.label or self._model.rno or ""  # type: ignore[union-attr]
+        return self._model.short_text or self._model.oz or ""  # type: ignore[union-attr]
+
+    @property
+    def rno(self) -> str:
+        if self._kind == NodeKind.ROOT:
+            return ""
+        if self._kind == NodeKind.ITEM:
+            return self._model.oz  # type: ignore[union-attr]
+        return self._model.rno  # type: ignore[union-attr]
+
+    @property
+    def label_path(self) -> list[str]:
+        """Labels from root to self (human-readable breadcrumb)."""
+        return [n.label for n in self.path]
+
+    # ------------------------------------------------------------------
+    # Subtree queries
+    # ------------------------------------------------------------------
+
+    def iter_descendants(self) -> Iterator[BoQNode]:
+        """Depth-first iteration over all descendants (excludes self)."""
+        stack = list(reversed(self._children))
+        while stack:
+            node = stack.pop()
+            yield node
+            stack.extend(reversed(node._children))
+
+    def iter_items(self) -> Iterator[BoQNode]:
+        """All ITEM-kind descendants (depth-first)."""
+        for node in self.iter_descendants():
+            if node._kind == NodeKind.ITEM:
+                yield node
+
+    def iter_categories(self) -> Iterator[BoQNode]:
+        """All CATEGORY-kind descendants (depth-first)."""
+        for node in self.iter_descendants():
+            if node._kind == NodeKind.CATEGORY:
+                yield node
+
+    def find(self, predicate: Callable[[BoQNode], bool]) -> BoQNode | None:
+        """First descendant matching predicate, or None."""
+        for node in self.iter_descendants():
+            if predicate(node):
+                return node
+        return None
+
+    def find_all(self, predicate: Callable[[BoQNode], bool]) -> list[BoQNode]:
+        """All descendants matching predicate."""
+        return [node for node in self.iter_descendants() if predicate(node)]
+
+
+_MAX_TREE_DEPTH = 50
+
+
+class BoQTree:
+    """Read-only tree adapter for a procurement BoQ.
+
+    Wraps an existing ``BoQ`` instance and builds a navigable node graph
+    with parent references, depth tracking, and indexed lookups. The
+    underlying Pydantic models are not modified.
+
+    Construction is O(n) where n is the total number of nodes.
+    """
+
+    __slots__ = ("_root", "_items_by_oz", "_node_count", "_item_count")
+
+    def __init__(self, boq: BoQ) -> None:
+        self._items_by_oz: dict[str, BoQNode] = {}
+        self._node_count = 0
+        self._item_count = 0
+        self._root = self._build_root(boq)
+
+    def __repr__(self) -> str:
+        return f"BoQTree(lots={len(self._root._children)}, nodes={self._node_count}, items={self._item_count})"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def root(self) -> BoQNode:
+        return self._root
+
+    @property
+    def lots(self) -> tuple[BoQNode, ...]:
+        return self._root._children
+
+    @property
+    def is_multi_lot(self) -> bool:
+        return len(self._root._children) > 1
+
+    @property
+    def node_count(self) -> int:
+        """Total nodes in the tree (all kinds including root)."""
+        return self._node_count
+
+    @property
+    def item_count(self) -> int:
+        """Total ITEM-kind nodes."""
+        return self._item_count
+
+    def find_item(self, oz: str) -> BoQNode | None:
+        """O(1) item lookup by OZ. Returns None if not found."""
+        return self._items_by_oz.get(oz)
+
+    def find_category(self, rno: str) -> BoQNode | None:
+        """First category node with this rno (depth-first). None if not found."""
+        return self._root.find(
+            lambda n: n._kind == NodeKind.CATEGORY and n.rno == rno
+        )
+
+    def find_all_categories(self, rno: str) -> list[BoQNode]:
+        """All category nodes with this rno (e.g. same rno in different lots)."""
+        return self._root.find_all(
+            lambda n: n._kind == NodeKind.CATEGORY and n.rno == rno
+        )
+
+    def walk(self) -> Iterator[BoQNode]:
+        """Depth-first iteration over all nodes (including root)."""
+        yield self._root
+        yield from self._root.iter_descendants()
+
+    def walk_bfs(self) -> Iterator[BoQNode]:
+        """Breadth-first iteration over all nodes (including root)."""
+        queue: deque[BoQNode] = deque([self._root])
+        while queue:
+            node = queue.popleft()
+            yield node
+            queue.extend(node._children)
+
+    # ------------------------------------------------------------------
+    # Tree construction (private)
+    # ------------------------------------------------------------------
+
+    def _build_root(self, boq: BoQ) -> BoQNode:
+        root = BoQNode(
+            kind=NodeKind.ROOT,
+            model=boq,
+            parent=None,
+            children=(),
+            depth=0,
+            index=0,
+        )
+        self._node_count += 1
+
+        lot_nodes: list[BoQNode] = []
+        for i, lot_model in enumerate(boq.lots):
+            lot_node = self._build_lot(lot_model, parent=root, index=i)
+            lot_nodes.append(lot_node)
+
+        root._children = tuple(lot_nodes)
+        return root
+
+    def _build_lot(self, lot_model: Lot, parent: BoQNode, index: int) -> BoQNode:
+        lot_node = BoQNode(
+            kind=NodeKind.LOT,
+            model=lot_model,
+            parent=parent,
+            children=(),
+            depth=1,
+            index=index,
+        )
+        self._node_count += 1
+
+        child_nodes: list[BoQNode] = []
+        for i, ctgy in enumerate(lot_model.body.categories):
+            ctgy_node = self._build_category(ctgy, parent=lot_node, depth=2, index=i)
+            child_nodes.append(ctgy_node)
+
+        lot_node._children = tuple(child_nodes)
+        return lot_node
+
+    def _build_category(
+        self, ctgy: BoQCtgy, parent: BoQNode, depth: int, index: int
+    ) -> BoQNode:
+        if depth > _MAX_TREE_DEPTH:
+            return BoQNode(
+                kind=NodeKind.CATEGORY,
+                model=ctgy,
+                parent=parent,
+                children=(),
+                depth=depth,
+                index=index,
+            )
+
+        ctgy_node = BoQNode(
+            kind=NodeKind.CATEGORY,
+            model=ctgy,
+            parent=parent,
+            children=(),
+            depth=depth,
+            index=index,
+        )
+        self._node_count += 1
+
+        child_nodes: list[BoQNode] = []
+
+        for i, sub in enumerate(ctgy.subcategories):
+            sub_node = self._build_category(sub, parent=ctgy_node, depth=depth + 1, index=i)
+            child_nodes.append(sub_node)
+
+        offset = len(child_nodes)
+        for i, item_model in enumerate(ctgy.items):
+            item_node = self._build_item(item_model, parent=ctgy_node, depth=depth + 1, index=offset + i)
+            child_nodes.append(item_node)
+
+        ctgy_node._children = tuple(child_nodes)
+        return ctgy_node
+
+    def _build_item(self, item_model: Item, parent: BoQNode, depth: int, index: int) -> BoQNode:
+        item_node = BoQNode(
+            kind=NodeKind.ITEM,
+            model=item_model,
+            parent=parent,
+            children=(),
+            depth=depth,
+            index=index,
+        )
+        self._node_count += 1
+        self._item_count += 1
+
+        if item_model.oz:
+            self._items_by_oz.setdefault(item_model.oz, item_node)
+
+        return item_node

--- a/tests/test_boq_tree.py
+++ b/tests/test_boq_tree.py
@@ -1,6 +1,6 @@
 """Tests for the read-only BoQ tree API (BoQTree, BoQNode, NodeKind)."""
 
-from __future__ import annotations
+from __future__ import annotations  # noqa: I001
 
 from decimal import Decimal
 

--- a/tests/test_boq_tree.py
+++ b/tests/test_boq_tree.py
@@ -1,0 +1,596 @@
+"""Tests for the read-only BoQ tree API (BoQTree, BoQNode, NodeKind)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from pygaeb.api.boq_tree import BoQTree, NodeKind
+from pygaeb.models.boq import BoQ, BoQBody, BoQCtgy, Lot
+from pygaeb.models.enums import ItemType
+from pygaeb.models.item import Item
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def nested_boq() -> BoQ:
+    """BoQ with nested subcategories: Lot > Rohbau > Mauerwerk > 2 items, Ausbau > 1 item."""
+    items_mauer = [
+        Item(oz="01.01.0010", short_text="Mauerwerk Innenwand", qty=Decimal("1170"),
+             unit="m2", unit_price=Decimal("45.50"), total_price=Decimal("53235.00"),
+             item_type=ItemType.NORMAL, hierarchy_path=["Rohbau", "Mauerwerk"]),
+        Item(oz="01.01.0020", short_text="Mauerwerk Aussenwand", qty=Decimal("850"),
+             unit="m2", unit_price=Decimal("68.00"), total_price=Decimal("57800.00"),
+             item_type=ItemType.NORMAL, hierarchy_path=["Rohbau", "Mauerwerk"]),
+    ]
+    items_ausbau = [
+        Item(oz="02.0010", short_text="Innentuer Holz", qty=Decimal("25"),
+             unit="Stk", unit_price=Decimal("450.00"), total_price=Decimal("11250.00"),
+             item_type=ItemType.NORMAL, hierarchy_path=["Ausbau"]),
+    ]
+    mauerwerk = BoQCtgy(rno="01", label="Mauerwerk", items=items_mauer)
+    rohbau = BoQCtgy(rno="01", label="Rohbau", subcategories=[mauerwerk])
+    ausbau = BoQCtgy(rno="02", label="Ausbau", items=items_ausbau)
+    lot = Lot(rno="1", label="Default", body=BoQBody(categories=[rohbau, ausbau]))
+    return BoQ(lots=[lot])
+
+
+@pytest.fixture
+def multi_lot_boq() -> BoQ:
+    """BoQ with 2 lots, each with 1 category. Lot 2 has an EVENTUAL item."""
+    lot1 = Lot(
+        rno="1", label="Los 1 - Erdarbeiten",
+        body=BoQBody(categories=[BoQCtgy(rno="01", label="Erdarbeiten", items=[
+            Item(oz="01.0010", short_text="Aushub", qty=Decimal("500"),
+                 unit="m3", total_price=Decimal("6000"), item_type=ItemType.NORMAL),
+        ])]),
+    )
+    lot2 = Lot(
+        rno="2", label="Los 2 - Beton",
+        body=BoQBody(categories=[BoQCtgy(rno="01", label="Beton", items=[
+            Item(oz="01.0010", short_text="Stahlbeton", qty=Decimal("80"),
+                 unit="m3", total_price=Decimal("14400"), item_type=ItemType.NORMAL),
+            Item(oz="01.0020", short_text="Pfahlgründung", qty=Decimal("1"),
+                 unit="psch", total_price=Decimal("25000"), item_type=ItemType.EVENTUAL),
+        ])]),
+    )
+    return BoQ(lots=[lot1, lot2])
+
+
+@pytest.fixture
+def empty_boq() -> BoQ:
+    """BoQ with one lot and one empty category."""
+    lot = Lot(rno="1", label="Empty Lot", body=BoQBody(categories=[
+        BoQCtgy(rno="01", label="Empty Section"),
+    ]))
+    return BoQ(lots=[lot])
+
+
+@pytest.fixture
+def tree(nested_boq: BoQ) -> BoQTree:
+    return BoQTree(nested_boq)
+
+
+@pytest.fixture
+def multi_tree(multi_lot_boq: BoQ) -> BoQTree:
+    return BoQTree(multi_lot_boq)
+
+
+# ── Root node ─────────────────────────────────────────────────────────
+
+
+class TestRoot:
+    def test_root_kind(self, tree: BoQTree) -> None:
+        assert tree.root.kind == NodeKind.ROOT
+
+    def test_root_has_no_parent(self, tree: BoQTree) -> None:
+        assert tree.root.parent is None
+        assert tree.root.is_root is True
+
+    def test_root_depth_is_zero(self, tree: BoQTree) -> None:
+        assert tree.root.depth == 0
+
+    def test_root_index_is_zero(self, tree: BoQTree) -> None:
+        assert tree.root.index == 0
+
+    def test_root_children_are_lots(self, tree: BoQTree) -> None:
+        for child in tree.root.children:
+            assert child.kind == NodeKind.LOT
+
+    def test_root_label(self, tree: BoQTree) -> None:
+        assert tree.root.label == "BoQ"
+
+    def test_root_rno_is_empty(self, tree: BoQTree) -> None:
+        assert tree.root.rno == ""
+
+    def test_root_boq_accessor(self, tree: BoQTree, nested_boq: BoQ) -> None:
+        assert tree.root.boq is nested_boq
+
+
+# ── Lot nodes ─────────────────────────────────────────────────────────
+
+
+class TestLotNode:
+    def test_lot_kind(self, tree: BoQTree) -> None:
+        assert tree.lots[0].kind == NodeKind.LOT
+
+    def test_lot_depth(self, tree: BoQTree) -> None:
+        assert tree.lots[0].depth == 1
+
+    def test_lot_parent_is_root(self, tree: BoQTree) -> None:
+        assert tree.lots[0].parent is tree.root
+
+    def test_lot_label(self, tree: BoQTree) -> None:
+        assert tree.lots[0].label == "Default"
+
+    def test_lot_rno(self, tree: BoQTree) -> None:
+        assert tree.lots[0].rno == "1"
+
+    def test_lot_accessor(self, tree: BoQTree) -> None:
+        lot_model = tree.lots[0].lot
+        assert lot_model.rno == "1"
+
+    def test_lot_children_are_categories(self, tree: BoQTree) -> None:
+        for child in tree.lots[0].children:
+            assert child.kind == NodeKind.CATEGORY
+
+
+# ── Category nodes ────────────────────────────────────────────────────
+
+
+class TestCategoryNode:
+    def test_category_kind(self, tree: BoQTree) -> None:
+        rohbau = tree.lots[0].children[0]
+        assert rohbau.kind == NodeKind.CATEGORY
+
+    def test_category_depth(self, tree: BoQTree) -> None:
+        rohbau = tree.lots[0].children[0]
+        assert rohbau.depth == 2
+        mauerwerk = rohbau.children[0]
+        assert mauerwerk.depth == 3
+
+    def test_category_label_and_rno(self, tree: BoQTree) -> None:
+        rohbau = tree.lots[0].children[0]
+        assert rohbau.label == "Rohbau"
+        assert rohbau.rno == "01"
+
+    def test_category_accessor(self, tree: BoQTree) -> None:
+        rohbau = tree.lots[0].children[0]
+        assert rohbau.category.label == "Rohbau"
+
+    def test_category_parent_is_lot(self, tree: BoQTree) -> None:
+        rohbau = tree.lots[0].children[0]
+        assert rohbau.parent is tree.lots[0]
+
+    def test_subcategory_parent_is_category(self, tree: BoQTree) -> None:
+        rohbau = tree.lots[0].children[0]
+        mauerwerk = rohbau.children[0]
+        assert mauerwerk.parent is rohbau
+
+
+# ── Item nodes ────────────────────────────────────────────────────────
+
+
+class TestItemNode:
+    def test_item_kind(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert item_node.kind == NodeKind.ITEM
+
+    def test_item_is_leaf(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert item_node.is_leaf is True
+        assert len(item_node.children) == 0
+
+    def test_item_depth(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert item_node.depth == 4
+
+    def test_item_accessor(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert item_node.item.oz == "01.01.0010"
+
+    def test_item_label_is_short_text(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert item_node.label == "Mauerwerk Innenwand"
+
+    def test_item_rno_is_oz(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert item_node.rno == "01.01.0010"
+
+    def test_item_parent_is_category(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert item_node.parent is mauerwerk
+        assert item_node.parent.label == "Mauerwerk"
+
+
+# ── Children ordering ─────────────────────────────────────────────────
+
+
+class TestChildrenOrder:
+    def test_subcategories_before_items(self, tree: BoQTree) -> None:
+        """Rohbau has 1 subcategory (Mauerwerk) and 0 items — children are just the subcategory."""
+        rohbau = tree.lots[0].children[0]
+        assert len(rohbau.children) == 1
+        assert rohbau.children[0].kind == NodeKind.CATEGORY
+
+    def test_items_in_leaf_category(self, tree: BoQTree) -> None:
+        """Mauerwerk has 0 subcategories and 2 items."""
+        mauerwerk = tree.lots[0].children[0].children[0]
+        assert len(mauerwerk.children) == 2
+        assert all(c.kind == NodeKind.ITEM for c in mauerwerk.children)
+
+    def test_children_immutable(self, tree: BoQTree) -> None:
+        assert isinstance(tree.root.children, tuple)
+        assert isinstance(tree.lots[0].children, tuple)
+
+
+# ── Parent / ancestor / path ──────────────────────────────────────────
+
+
+class TestParentChain:
+    def test_full_parent_chain(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert item_node.parent.label == "Mauerwerk"
+        assert item_node.parent.parent.label == "Rohbau"
+        assert item_node.parent.parent.parent.label == "Default"
+        assert item_node.parent.parent.parent.parent is tree.root
+
+    def test_ancestors(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        ancestors = item_node.ancestors
+        assert len(ancestors) == 4
+        assert ancestors[0] is tree.root
+        assert ancestors[-1] is mauerwerk
+
+    def test_path_includes_self(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        path = item_node.path
+        assert path[-1] is item_node
+        assert path[0] is tree.root
+
+    def test_label_path(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        expected = ["BoQ", "Default", "Rohbau", "Mauerwerk", "Mauerwerk Innenwand"]
+        assert item_node.label_path == expected
+
+    def test_root_ancestors_empty(self, tree: BoQTree) -> None:
+        assert tree.root.ancestors == ()
+
+    def test_root_path_is_just_self(self, tree: BoQTree) -> None:
+        assert tree.root.path == (tree.root,)
+
+
+# ── Siblings ──────────────────────────────────────────────────────────
+
+
+class TestSiblings:
+    def test_item_siblings(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        first_item = mauerwerk.children[0]
+        second_item = mauerwerk.children[1]
+        assert first_item.siblings == (second_item,)
+        assert second_item.siblings == (first_item,)
+
+    def test_category_siblings(self, tree: BoQTree) -> None:
+        lot = tree.lots[0]
+        rohbau = lot.children[0]
+        ausbau = lot.children[1]
+        assert rohbau.siblings == (ausbau,)
+        assert ausbau.siblings == (rohbau,)
+
+    def test_root_siblings_empty(self, tree: BoQTree) -> None:
+        assert tree.root.siblings == ()
+
+    def test_next_sibling(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        first_item = mauerwerk.children[0]
+        second_item = mauerwerk.children[1]
+        assert first_item.next_sibling is second_item
+        assert second_item.next_sibling is None
+
+    def test_prev_sibling(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        first_item = mauerwerk.children[0]
+        second_item = mauerwerk.children[1]
+        assert first_item.prev_sibling is None
+        assert second_item.prev_sibling is first_item
+
+    def test_index_values(self, tree: BoQTree) -> None:
+        lot = tree.lots[0]
+        assert lot.children[0].index == 0
+        assert lot.children[1].index == 1
+
+
+# ── find_item / find_category ─────────────────────────────────────────
+
+
+class TestLookups:
+    def test_find_item_by_oz(self, tree: BoQTree) -> None:
+        node = tree.find_item("01.01.0010")
+        assert node is not None
+        assert node.kind == NodeKind.ITEM
+        assert node.item.short_text == "Mauerwerk Innenwand"
+
+    def test_find_item_missing(self, tree: BoQTree) -> None:
+        assert tree.find_item("nonexistent") is None
+
+    def test_find_category_by_rno(self, tree: BoQTree) -> None:
+        node = tree.find_category("02")
+        assert node is not None
+        assert node.label == "Ausbau"
+
+    def test_find_category_missing(self, tree: BoQTree) -> None:
+        assert tree.find_category("99") is None
+
+    def test_find_all_categories_same_rno(self, multi_tree: BoQTree) -> None:
+        nodes = multi_tree.find_all_categories("01")
+        assert len(nodes) == 2
+        labels = {n.label for n in nodes}
+        assert labels == {"Erdarbeiten", "Beton"}
+
+    def test_find_item_duplicate_oz_returns_first(self, multi_tree: BoQTree) -> None:
+        """When the same OZ exists in multiple lots, find_item returns the first."""
+        node = multi_tree.find_item("01.0010")
+        assert node is not None
+        assert node.item.short_text == "Aushub"
+
+
+# ── iter_items / iter_categories / iter_descendants ───────────────────
+
+
+class TestIteration:
+    def test_iter_items_from_root(self, tree: BoQTree) -> None:
+        items = list(tree.root.iter_items())
+        assert len(items) == 3
+        assert all(n.kind == NodeKind.ITEM for n in items)
+
+    def test_iter_items_from_category(self, tree: BoQTree) -> None:
+        rohbau = tree.lots[0].children[0]
+        items = list(rohbau.iter_items())
+        assert len(items) == 2
+
+    def test_iter_categories_from_root(self, tree: BoQTree) -> None:
+        cats = list(tree.root.iter_categories())
+        labels = [c.label for c in cats]
+        assert "Rohbau" in labels
+        assert "Mauerwerk" in labels
+        assert "Ausbau" in labels
+
+    def test_iter_descendants_dfs_order(self, tree: BoQTree) -> None:
+        descendants = list(tree.root.iter_descendants())
+        kinds = [n.kind for n in descendants]
+        assert kinds[0] == NodeKind.LOT
+        assert NodeKind.CATEGORY in kinds
+        assert NodeKind.ITEM in kinds
+
+    def test_iter_descendants_excludes_self(self, tree: BoQTree) -> None:
+        descendants = list(tree.root.iter_descendants())
+        assert tree.root not in descendants
+
+    def test_leaf_has_no_descendants(self, tree: BoQTree) -> None:
+        mauerwerk = tree.lots[0].children[0].children[0]
+        item_node = mauerwerk.children[0]
+        assert list(item_node.iter_descendants()) == []
+        assert list(item_node.iter_items()) == []
+
+
+# ── find / find_all (predicate) ──────────────────────────────────────
+
+
+class TestFindPredicate:
+    def test_find_by_unit(self, tree: BoQTree) -> None:
+        node = tree.root.find(
+            lambda n: n.kind == NodeKind.ITEM and n.item.unit == "Stk"
+        )
+        assert node is not None
+        assert node.item.short_text == "Innentuer Holz"
+
+    def test_find_returns_none_when_no_match(self, tree: BoQTree) -> None:
+        result = tree.root.find(lambda n: False)
+        assert result is None
+
+    def test_find_all(self, tree: BoQTree) -> None:
+        nodes = tree.root.find_all(
+            lambda n: n.kind == NodeKind.ITEM and n.item.unit == "m2"
+        )
+        assert len(nodes) == 2
+
+
+# ── walk / walk_bfs ──────────────────────────────────────────────────
+
+
+class TestWalk:
+    def test_walk_visits_all_nodes(self, tree: BoQTree) -> None:
+        all_nodes = list(tree.walk())
+        assert len(all_nodes) == tree.node_count
+
+    def test_walk_starts_with_root(self, tree: BoQTree) -> None:
+        all_nodes = list(tree.walk())
+        assert all_nodes[0] is tree.root
+
+    def test_walk_dfs_order(self, tree: BoQTree) -> None:
+        """DFS: root → lot → rohbau → mauerwerk → items → ausbau → item."""
+        all_nodes = list(tree.walk())
+        labels = [n.label for n in all_nodes]
+        rohbau_idx = labels.index("Rohbau")
+        mauerwerk_idx = labels.index("Mauerwerk")
+        ausbau_idx = labels.index("Ausbau")
+        assert rohbau_idx < mauerwerk_idx < ausbau_idx
+
+    def test_walk_bfs_visits_all_nodes(self, tree: BoQTree) -> None:
+        all_nodes = list(tree.walk_bfs())
+        assert len(all_nodes) == tree.node_count
+
+    def test_walk_bfs_order(self, tree: BoQTree) -> None:
+        """BFS: root first, then lots, then top-level categories, then deeper."""
+        all_nodes = list(tree.walk_bfs())
+        depths = [n.depth for n in all_nodes]
+        assert depths == sorted(depths)
+
+
+# ── Counts ────────────────────────────────────────────────────────────
+
+
+class TestCounts:
+    def test_item_count(self, tree: BoQTree) -> None:
+        assert tree.item_count == 3
+
+    def test_node_count(self, tree: BoQTree) -> None:
+        # root(1) + lot(1) + rohbau(1) + mauerwerk(1) + ausbau(1) + items(3) = 8
+        assert tree.node_count == 8
+
+    def test_multi_lot_item_count(self, multi_tree: BoQTree) -> None:
+        assert multi_tree.item_count == 3
+
+    def test_multi_lot_node_count(self, multi_tree: BoQTree) -> None:
+        # root(1) + lot1(1) + erdarbeiten(1) + item(1)
+        # + lot2(1) + beton(1) + items(2) = 8
+        assert multi_tree.node_count == 8
+
+
+# ── Multi-lot ─────────────────────────────────────────────────────────
+
+
+class TestMultiLot:
+    def test_is_multi_lot(self, multi_tree: BoQTree) -> None:
+        assert multi_tree.is_multi_lot is True
+
+    def test_single_lot_not_multi(self, tree: BoQTree) -> None:
+        assert tree.is_multi_lot is False
+
+    def test_lot_count(self, multi_tree: BoQTree) -> None:
+        assert len(multi_tree.lots) == 2
+
+    def test_lots_property_matches_root_children(self, multi_tree: BoQTree) -> None:
+        assert multi_tree.lots is multi_tree.root.children
+
+    def test_items_per_lot(self, multi_tree: BoQTree) -> None:
+        lot1_items = list(multi_tree.lots[0].iter_items())
+        lot2_items = list(multi_tree.lots[1].iter_items())
+        assert len(lot1_items) == 1
+        assert len(lot2_items) == 2
+
+
+# ── Type-safe accessor errors ─────────────────────────────────────────
+
+
+class TestTypeSafeAccessors:
+    def test_lot_accessor_on_root_raises(self, tree: BoQTree) -> None:
+        with pytest.raises(TypeError, match="lot"):
+            _ = tree.root.lot
+
+    def test_item_accessor_on_lot_raises(self, tree: BoQTree) -> None:
+        with pytest.raises(TypeError, match="item"):
+            _ = tree.lots[0].item
+
+    def test_category_accessor_on_item_raises(self, tree: BoQTree) -> None:
+        node = tree.find_item("01.01.0010")
+        assert node is not None
+        with pytest.raises(TypeError, match="category"):
+            _ = node.category
+
+    def test_boq_accessor_on_category_raises(self, tree: BoQTree) -> None:
+        rohbau = tree.lots[0].children[0]
+        with pytest.raises(TypeError, match="boq"):
+            _ = rohbau.boq
+
+
+# ── Empty category ────────────────────────────────────────────────────
+
+
+class TestEmptyCategory:
+    def test_empty_category_is_leaf(self, empty_boq: BoQ) -> None:
+        tree = BoQTree(empty_boq)
+        ctgy_node = tree.lots[0].children[0]
+        assert ctgy_node.is_leaf is True
+        assert len(ctgy_node.children) == 0
+
+    def test_empty_category_iter_items_empty(self, empty_boq: BoQ) -> None:
+        tree = BoQTree(empty_boq)
+        ctgy_node = tree.lots[0].children[0]
+        assert list(ctgy_node.iter_items()) == []
+
+
+# ── Model identity ────────────────────────────────────────────────────
+
+
+class TestModelIdentity:
+    def test_node_wraps_same_object(self, tree: BoQTree, nested_boq: BoQ) -> None:
+        """BoQNode.model returns the original Pydantic object, not a copy."""
+        assert tree.root.model is nested_boq
+        lot_model = nested_boq.lots[0]
+        assert tree.lots[0].model is lot_model
+
+    def test_item_model_identity(self, tree: BoQTree, nested_boq: BoQ) -> None:
+        original_item = nested_boq.lots[0].body.categories[0].subcategories[0].items[0]
+        node = tree.find_item("01.01.0010")
+        assert node is not None
+        assert node.model is original_item
+
+
+# ── Repr ──────────────────────────────────────────────────────────────
+
+
+class TestRepr:
+    def test_node_repr(self, tree: BoQTree) -> None:
+        r = repr(tree.lots[0])
+        assert "lot" in r
+        assert "Default" in r
+
+    def test_tree_repr(self, tree: BoQTree) -> None:
+        r = repr(tree)
+        assert "BoQTree" in r
+        assert "items=3" in r
+
+    def test_item_node_repr(self, tree: BoQTree) -> None:
+        node = tree.find_item("01.01.0010")
+        assert node is not None
+        r = repr(node)
+        assert "item" in r
+        assert "01.01.0010" in r
+
+
+# ── Construction from existing conftest fixtures ──────────────────────
+
+
+class TestWithConftestFixtures:
+    """Verify BoQTree works with the standard conftest sample_document and multi_lot_document."""
+
+    def test_from_sample_document(self, sample_document) -> None:
+        tree = BoQTree(sample_document.award.boq)
+        assert tree.item_count == sample_document.item_count
+        assert tree.is_multi_lot is False
+
+    def test_from_multi_lot_document(self, multi_lot_document) -> None:
+        tree = BoQTree(multi_lot_document.award.boq)
+        assert tree.item_count == multi_lot_document.item_count
+        assert tree.is_multi_lot is True
+        assert len(tree.lots) == 2
+
+    def test_navigate_sample_document(self, sample_document) -> None:
+        tree = BoQTree(sample_document.award.boq)
+        node = tree.find_item("01.01.0010")
+        assert node is not None
+        assert node.parent is not None
+        assert node.parent.kind == NodeKind.CATEGORY
+
+    def test_walk_sample_document(self, sample_document) -> None:
+        tree = BoQTree(sample_document.award.boq)
+        all_nodes = list(tree.walk())
+        assert len(all_nodes) == tree.node_count
+        item_nodes = [n for n in all_nodes if n.kind == NodeKind.ITEM]
+        assert len(item_nodes) == 3


### PR DESCRIPTION
…ookups

Introduces BoQTree, BoQNode, and NodeKind — a read-only adapter layer over the existing BoQ model that provides O(1) parent, children, depth, and sibling navigation without modifying the underlying Pydantic models.
- BoQNode: parent, children, siblings, ancestors, path, depth, index, next/prev sibling, type-safe model accessors, subtree queries
- BoQTree: O(1) find_item(oz), find_category(rno), DFS/BFS walk
- NodeKind enum: ROOT, LOT, CATEGORY, ITEM
- 87 new tests, tree navigation guide, API reference docs
- Exported via lazy imports (zero cost if unused)