### PR TITLE
feat: add Excel export with hierarchy-aware layout for all GAEB docum…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-03-24
+
+### Added
+
+- **Excel Export** — `to_excel()` exports any GAEB document to a structured Excel workbook (.xlsx) with hierarchy-aware layout and phase-specific columns.
+- **Two export modes** — `mode="structured"` for a single hierarchy-aware sheet; `mode="full"` for a multi-sheet workbook (BoQ + Items + Summary + Info).
+- **All document kinds** — Procurement (X80-X89), Trade (X93-X97), Cost (X50-X52), and Quantity Determination (X31) each get phase-appropriate columns.
+- **Optional columns** — `include_long_text`, `include_classification`, and `include_bim_guid` flags add extra columns on demand.
+- **Minimal formatting** — Bold headers, frozen panes, auto column widths, currency/quantity number formatting, bold subtotals.
+- Optional dependency: `openpyxl` via `pip install pyGAEB[excel]`.
+- New export: `to_excel` (top-level lazy import and via `pygaeb.convert`).
+- 34 new tests covering all 4 phases, both modes, column flags, formatting, and edge cases.
+
 ## [1.10.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An optional LLM classification layer enriches each item with a semantic construc
 - **LLM classification** — 100+ provider support via LiteLLM with cost estimation and persistent caching
 - **Document diff** — Compare two BoQs with significance-classified field changes, structural diff, and financial impact
 - **BoQ Builder** — Programmatic document construction with auto OZ, Decimal convenience, phase rules, and version checks
+- **Excel export** — Structured .xlsx workbooks with hierarchy-aware layout, phase-specific columns, and multi-sheet mode
 - **Round-trip** — Parse → modify → write back to any DA XML version
 - **Version conversion** — Upgrade/downgrade between DA XML 2.0–3.3
 
@@ -284,6 +285,24 @@ doc = builder.build()               # GAEBDocument with auto totals
 GAEBWriter.write(doc, "output.X83") # Write to GAEB XML
 ```
 
+### Excel Export
+
+```python
+from pygaeb import GAEBParser
+from pygaeb.convert import to_excel
+
+doc = GAEBParser.parse("tender.X83")
+
+# Single structured sheet with hierarchy
+to_excel(doc, "tender.xlsx")
+
+# Multi-sheet workbook (BoQ + Items + Summary + Info)
+to_excel(doc, "tender_full.xlsx", mode="full")
+
+# With optional columns
+to_excel(doc, "detailed.xlsx", include_long_text=True, include_classification=True)
+```
+
 ### LLM Classification
 
 ```python
@@ -495,6 +514,7 @@ Full documentation is available at [Read the Docs](https://pygaeb.readthedocs.io
 - [Tree Navigation](https://pygaeb.readthedocs.io/guides/tree-navigation/)
 - [Document Diff](https://pygaeb.readthedocs.io/guides/document-diff/)
 - [BoQ Builder](https://pygaeb.readthedocs.io/guides/builder/)
+- [Excel Export](https://pygaeb.readthedocs.io/guides/excel-export/)
 - [Extensibility](https://pygaeb.readthedocs.io/guides/extensibility/)
 - [Classification](https://pygaeb.readthedocs.io/guides/classification/)
 - [Version Conversion](https://pygaeb.readthedocs.io/guides/conversion/)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,16 @@ All notable changes to pyGAEB are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-03-24
+
+### Added
+
+- **Excel Export** — `to_excel()` exports any GAEB document to structured Excel workbooks with hierarchy-aware layout and phase-specific columns.
+- Two export modes: `structured` (single sheet) and `full` (BoQ + Items + Summary + Info sheets).
+- All document kinds supported with phase-appropriate columns.
+- Optional columns via `include_long_text`, `include_classification`, `include_bim_guid`.
+- 34 new tests.
+
 ## [1.10.0] - 2026-03-24
 
 ### Added

--- a/docs/guides/excel-export.md
+++ b/docs/guides/excel-export.md
@@ -1,0 +1,132 @@
+# Excel Export
+
+Export any GAEB document to a structured Excel workbook with hierarchy-aware layout, phase-specific columns, and optional classification data.
+
+## Installation
+
+Excel export requires `openpyxl`:
+
+```bash
+pip install pyGAEB[excel]
+```
+
+## Quick Start
+
+```python
+from pygaeb import GAEBParser
+from pygaeb.convert import to_excel
+
+doc = GAEBParser.parse("tender.X83")
+to_excel(doc, "tender.xlsx")
+```
+
+## Export Modes
+
+### Structured (default)
+
+A single sheet with lots and categories as header rows, items as data rows, subtotals, and a grand total:
+
+```python
+to_excel(doc, "output.xlsx", mode="structured")
+```
+
+The sheet layout preserves the BoQ hierarchy:
+
+```
+OZ       | Description      | Qty | Unit | Unit Price | Total Price
+---------|------------------|-----|------|------------|------------
+Lot 1 — Structural Work
+  01 — Concrete
+  01.0010 | Foundation       | 120 | m3   | 85.00      | 10,200.00
+  01.0020 | Columns          | 40  | m3   | 95.00      | 3,800.00
+  Subtotal 01: 14,000.00
+Lot Subtotal: 54,800.00
+GRAND TOTAL: 54,800.00
+```
+
+### Full (multi-sheet)
+
+Four sheets for comprehensive reporting:
+
+```python
+to_excel(doc, "output.xlsx", mode="full")
+```
+
+| Sheet | Content |
+|-------|---------|
+| **BoQ** | Same structured layout as above |
+| **Items** | Flat table with one row per item (filterable/pivotable) |
+| **Summary** | Per-lot totals, item counts, grand total |
+| **Info** | Project metadata: name, phase, version, currency |
+
+## All Document Types Supported
+
+The exporter auto-detects the document kind and uses appropriate columns:
+
+```python
+# Procurement (X80-X89)
+doc = GAEBParser.parse("tender.X83")
+to_excel(doc, "procurement.xlsx")
+
+# Trade (X93-X97)
+doc = GAEBParser.parse("order.X96")
+to_excel(doc, "trade.xlsx")
+
+# Cost (X50-X52)
+doc = GAEBParser.parse("cost.X50")
+to_excel(doc, "cost.xlsx")
+
+# Quantity Determination (X31)
+doc = GAEBParser.parse("qty.X31")
+to_excel(doc, "quantity.xlsx")
+```
+
+### Phase-Specific Columns
+
+| Document Kind | Default Columns |
+|--------------|----------------|
+| Procurement | OZ, Description, Qty, Unit, Unit Price, Total Price, Computed Total, Item Type, Hierarchy |
+| Trade | Item ID, Article No., Description, Qty, Unit, Offer Price, Net Price, Service |
+| Cost | Element No., Description, Qty, Unit, Unit Price, Total, Markup, Category ID |
+| Quantity | OZ, RNo Part, Qty, Determinations |
+
+## Optional Columns
+
+Add extra columns via include flags:
+
+```python
+to_excel(
+    doc,
+    "output.xlsx",
+    include_long_text=True,         # "Long Text" column
+    include_classification=True,    # Trade, Element Type, Confidence columns
+    include_bim_guid=True,          # BIM GUID column (procurement only)
+)
+```
+
+## Formatting
+
+The exporter applies minimal, clean formatting:
+
+- **Bold headers** with frozen first row
+- **Auto column widths** based on content (capped at 60 characters)
+- **Number formatting**: currency columns use `#,##0.00`, quantity columns use `#,##0.###`
+- **Bold section headers** for lots and categories
+- **Bold subtotals** and grand total
+
+## Built Documents
+
+Documents created with `BoQBuilder` export directly:
+
+```python
+from pygaeb import BoQBuilder
+from pygaeb.convert import to_excel
+
+builder = BoQBuilder(phase="X83", version="3.3")
+builder.project(no="PRJ-001", name="Office Building", currency="EUR")
+cat = builder.add_category("01", "Concrete")
+cat.add_item("01.0010", "Foundation", qty=120, unit="m3", unit_price=85)
+
+doc = builder.build()
+to_excel(doc, "built.xlsx", mode="full")
+```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -16,3 +16,4 @@ In-depth guides for every pyGAEB capability.
 - **[Tree Navigation](tree-navigation.md)** — BoQTree adapter with parent references, sibling navigation, depth tracking, and subtree queries
 - **[Document Diff](document-diff.md)** — compare two GAEB documents with significance-classified field changes, structural diff, and financial impact
 - **[BoQ Builder](builder.md)** — programmatic document construction with auto OZ, Decimal convenience, phase rules, and version checks
+- **[Excel Export](excel-export.md)** — export any GAEB document to structured Excel workbooks with phase-specific columns

--- a/docs/reference/excel-export.md
+++ b/docs/reference/excel-export.md
@@ -1,0 +1,9 @@
+# Excel Export API Reference
+
+## to_excel
+
+::: pygaeb.convert.to_excel.to_excel
+
+## ColumnDef
+
+::: pygaeb.convert.to_excel.ColumnDef

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,4 +21,5 @@ Complete reference documentation for all public classes, functions, and enums in
 - **[BoQ Tree](boq-tree.md)** — `BoQTree`, `BoQNode`, `NodeKind`
 - **[Document Diff](document-diff.md)** — `BoQDiff`, `DiffResult`, `Significance`, `DiffMode`
 - **[BoQ Builder](builder.md)** — `BoQBuilder`, `LotBuilder`, `CategoryBuilder`, `ItemHandle`
+- **[Excel Export](excel-export.md)** — `to_excel`, `ColumnDef`
 - **[Exceptions](exceptions.md)** — exception hierarchy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - Tree Navigation: guides/tree-navigation.md
     - Document Diff: guides/document-diff.md
     - BoQ Builder: guides/builder.md
+    - Excel Export: guides/excel-export.md
     - Extensibility: guides/extensibility.md
   - API Reference:
     - reference/index.md
@@ -105,6 +106,7 @@ nav:
     - BoQ Tree: reference/boq-tree.md
     - Document Diff: reference/document-diff.md
     - BoQ Builder: reference/builder.md
+    - Excel Export: reference/excel-export.md
     - Validation: reference/validation.md
     - Configuration: reference/config.md
     - Exceptions: reference/exceptions.md

--- a/pygaeb/__init__.py
+++ b/pygaeb/__init__.py
@@ -12,7 +12,7 @@ Quick start:
 
 from __future__ import annotations
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 
 from pygaeb.exceptions import (
     ClassificationBackendError,
@@ -132,6 +132,8 @@ def __getattr__(name: str) -> object:
         "NodeKind": ("pygaeb.api.boq_tree", "NodeKind"),
         # Builder
         "BoQBuilder": ("pygaeb.builder", "BoQBuilder"),
+        # Convert
+        "to_excel": ("pygaeb.convert.to_excel", "to_excel"),
         # Diff engine
         "BoQDiff": ("pygaeb.diff.boq_diff", "BoQDiff"),
         "DiffMode": ("pygaeb.diff.models", "DiffMode"),
@@ -272,4 +274,5 @@ __all__ = [
     "register_prompt",
     "register_validator",
     "reset_settings",
+    "to_excel",
 ]

--- a/pygaeb/convert/__init__.py
+++ b/pygaeb/convert/__init__.py
@@ -1,6 +1,7 @@
-"""Export converters: CSV and JSON."""
+"""Export converters: CSV, JSON, and Excel."""
 
 from pygaeb.convert.to_csv import to_csv
+from pygaeb.convert.to_excel import to_excel
 from pygaeb.convert.to_json import to_json, to_json_string
 
-__all__ = ["to_csv", "to_json", "to_json_string"]
+__all__ = ["to_csv", "to_excel", "to_json", "to_json_string"]

--- a/pygaeb/convert/to_excel.py
+++ b/pygaeb/convert/to_excel.py
@@ -566,4 +566,4 @@ def _apply_formatting_auto(ws: Any) -> None:
 
 def _col_letter(col_idx: int) -> str:
     from openpyxl.utils import get_column_letter
-    return get_column_letter(col_idx)
+    return str(get_column_letter(col_idx))

--- a/pygaeb/convert/to_excel.py
+++ b/pygaeb/convert/to_excel.py
@@ -1,0 +1,569 @@
+"""Export GAEBDocument to Excel (.xlsx) with structure-aware layout.
+
+Supports all four document kinds (procurement, trade, cost, quantity) and
+two modes: ``structured`` (single hierarchy-aware sheet) or ``full``
+(multi-sheet workbook with BoQ, Items, Summary, and Info sheets).
+
+Requires ``openpyxl``: ``pip install pyGAEB[excel]``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from pygaeb.models.document import GAEBDocument
+from pygaeb.models.enums import DocumentKind
+
+_CURRENCY_FMT = '#,##0.00'
+_QTY_FMT = '#,##0.###'
+_MAX_COL_WIDTH = 60
+_MIN_COL_WIDTH = 8
+
+
+@dataclass(frozen=True)
+class ColumnDef:
+    """Definition of an Excel column."""
+
+    key: str
+    header: str
+    width: int = 14
+    number_format: str | None = None
+
+
+_PROCUREMENT_COLS = [
+    ColumnDef("oz", "OZ", 14),
+    ColumnDef("short_text", "Description", 40),
+    ColumnDef("qty", "Qty", 12, _QTY_FMT),
+    ColumnDef("unit", "Unit", 8),
+    ColumnDef("unit_price", "Unit Price", 14, _CURRENCY_FMT),
+    ColumnDef("total_price", "Total Price", 16, _CURRENCY_FMT),
+    ColumnDef("computed_total", "Computed Total", 16, _CURRENCY_FMT),
+    ColumnDef("item_type", "Item Type", 14),
+    ColumnDef("hierarchy_path", "Hierarchy", 30),
+]
+
+_TRADE_COLS = [
+    ColumnDef("item_id", "Item ID", 14),
+    ColumnDef("art_no", "Article No.", 16),
+    ColumnDef("short_text", "Description", 40),
+    ColumnDef("qty", "Qty", 12, _QTY_FMT),
+    ColumnDef("unit", "Unit", 8),
+    ColumnDef("offer_price", "Offer Price", 14, _CURRENCY_FMT),
+    ColumnDef("net_price", "Net Price", 14, _CURRENCY_FMT),
+    ColumnDef("is_service", "Service", 10),
+]
+
+_COST_COLS = [
+    ColumnDef("ele_no", "Element No.", 14),
+    ColumnDef("short_text", "Description", 40),
+    ColumnDef("qty", "Qty", 12, _QTY_FMT),
+    ColumnDef("unit", "Unit", 8),
+    ColumnDef("unit_price", "Unit Price", 14, _CURRENCY_FMT),
+    ColumnDef("item_total", "Total", 16, _CURRENCY_FMT),
+    ColumnDef("markup", "Markup", 12, _QTY_FMT),
+    ColumnDef("cat_id", "Category ID", 14),
+]
+
+_QTY_COLS = [
+    ColumnDef("oz", "OZ", 14),
+    ColumnDef("rno_part", "RNo Part", 12),
+    ColumnDef("qty", "Qty", 12, _QTY_FMT),
+    ColumnDef("determ_count", "Determinations", 16),
+]
+
+_OPTIONAL_COLS = {
+    "long_text": ColumnDef("long_text_plain", "Long Text", 50),
+    "classification_trade": ColumnDef("classification_trade", "Trade", 16),
+    "classification_element": ColumnDef("classification_element_type", "Element Type", 20),
+    "classification_confidence": ColumnDef("classification_confidence", "Confidence", 12, '0.00'),
+    "bim_guid": ColumnDef("bim_guid", "BIM GUID", 36),
+}
+
+_COLUMNS_BY_KIND = {
+    DocumentKind.PROCUREMENT: _PROCUREMENT_COLS,
+    DocumentKind.TRADE: _TRADE_COLS,
+    DocumentKind.COST: _COST_COLS,
+    DocumentKind.QUANTITY: _QTY_COLS,
+}
+
+
+def _ensure_openpyxl() -> Any:
+    try:
+        import openpyxl
+        return openpyxl
+    except ImportError:
+        raise ImportError(
+            "Excel export requires openpyxl. Install it with: pip install pyGAEB[excel]"
+        ) from None
+
+
+def _get_columns(
+    doc: GAEBDocument,
+    include_long_text: bool,
+    include_classification: bool,
+    include_bim_guid: bool,
+) -> list[ColumnDef]:
+    cols = list(_COLUMNS_BY_KIND[doc.document_kind])
+    if include_long_text:
+        cols.append(_OPTIONAL_COLS["long_text"])
+    if include_classification:
+        cols.append(_OPTIONAL_COLS["classification_trade"])
+        cols.append(_OPTIONAL_COLS["classification_element"])
+        cols.append(_OPTIONAL_COLS["classification_confidence"])
+    if include_bim_guid and doc.document_kind == DocumentKind.PROCUREMENT:
+        cols.append(_OPTIONAL_COLS["bim_guid"])
+    return cols
+
+
+def _get_item_value(item: Any, col: ColumnDef) -> Any:
+    """Extract a value from an item for a given column definition."""
+    key = col.key
+    if key == "computed_total":
+        return getattr(item, "computed_total", None)
+    if key == "hierarchy_path":
+        path = getattr(item, "hierarchy_path", None)
+        return " > ".join(path) if path else ""
+    if key == "item_type":
+        it = getattr(item, "item_type", None)
+        return it.value if it is not None else ""
+    if key == "determ_count":
+        determ = getattr(item, "determ_items", None)
+        return len(determ) if determ else 0
+    if key == "long_text_plain":
+        return getattr(item, "long_text_plain", "")
+    if key.startswith("classification_"):
+        cls_obj = getattr(item, "classification", None)
+        if cls_obj is None:
+            return ""
+        suffix = key.replace("classification_", "")
+        return getattr(cls_obj, suffix, "")
+    if key == "is_service":
+        return "Yes" if getattr(item, "is_service", False) else ""
+
+    val = getattr(item, key, None)
+    if isinstance(val, Decimal):
+        return float(val)
+    return val if val is not None else ""
+
+
+def to_excel(
+    doc: GAEBDocument,
+    path: str | Path,
+    *,
+    mode: str = "structured",
+    include_long_text: bool = False,
+    include_classification: bool = False,
+    include_bim_guid: bool = False,
+) -> None:
+    """Export a GAEBDocument to an Excel workbook.
+
+    Args:
+        doc: The document to export.
+        path: Output file path (.xlsx).
+        mode: ``"structured"`` for a single hierarchy-aware sheet, or
+              ``"full"`` for a multi-sheet workbook (BoQ + Items + Summary + Info).
+        include_long_text: Add a "Long Text" column.
+        include_classification: Add classification columns (trade, element_type, confidence).
+        include_bim_guid: Add a "BIM GUID" column (procurement only).
+    """
+    openpyxl = _ensure_openpyxl()
+    if mode not in ("structured", "full"):
+        raise ValueError(f"Invalid mode {mode!r}. Use 'structured' or 'full'.")
+
+    wb = openpyxl.Workbook()
+    columns = _get_columns(doc, include_long_text, include_classification, include_bim_guid)
+
+    ws_boq = wb.active
+    ws_boq.title = "BoQ"
+    _write_structured_sheet(ws_boq, doc, columns)
+    _apply_formatting(ws_boq, columns)
+
+    if mode == "full":
+        ws_items = wb.create_sheet("Items")
+        _write_flat_items(ws_items, doc, columns)
+        _apply_formatting(ws_items, columns)
+
+        ws_summary = wb.create_sheet("Summary")
+        _write_summary_sheet(ws_summary, doc)
+        _apply_formatting_auto(ws_summary)
+
+        ws_info = wb.create_sheet("Info")
+        _write_info_sheet(ws_info, doc)
+        _apply_formatting_auto(ws_info)
+
+    wb.save(Path(path))
+
+
+# ---------------------------------------------------------------------------
+# Structured sheet writers (dispatched by DocumentKind)
+# ---------------------------------------------------------------------------
+
+def _write_structured_sheet(ws: Any, doc: GAEBDocument, columns: list[ColumnDef]) -> None:
+    kind = doc.document_kind
+    writers = {
+        DocumentKind.PROCUREMENT: _write_procurement_structured,
+        DocumentKind.TRADE: _write_trade_structured,
+        DocumentKind.COST: _write_cost_structured,
+        DocumentKind.QUANTITY: _write_quantity_structured,
+    }
+    writers[kind](ws, doc, columns)
+
+
+def _write_header_row(ws: Any, columns: list[ColumnDef], row: int = 1) -> int:
+    from openpyxl.styles import Font
+
+    for col_idx, col_def in enumerate(columns, 1):
+        cell = ws.cell(row=row, column=col_idx, value=col_def.header)
+        cell.font = Font(bold=True)
+    return row + 1
+
+
+def _write_item_row(
+    ws: Any, row: int, item: Any, columns: list[ColumnDef]
+) -> int:
+    for col_idx, col_def in enumerate(columns, 1):
+        val = _get_item_value(item, col_def)
+        cell = ws.cell(row=row, column=col_idx, value=val)
+        if col_def.number_format and isinstance(val, (int, float)):
+            cell.number_format = col_def.number_format
+    return row + 1
+
+
+def _write_label_row(
+    ws: Any, row: int, label: str, columns: list[ColumnDef], *, bold: bool = True
+) -> int:
+    from openpyxl.styles import Font
+
+    cell = ws.cell(row=row, column=1, value=label)
+    cell.font = Font(bold=bold)
+    return row + 1
+
+
+def _write_subtotal_row(
+    ws: Any, row: int, label: str, value: Decimal | float, columns: list[ColumnDef]
+) -> int:
+    from openpyxl.styles import Font
+
+    total_col = _find_total_column(columns)
+    cell_label = ws.cell(row=row, column=max(1, total_col - 1), value=label)
+    cell_label.font = Font(bold=True)
+    val = float(value) if isinstance(value, Decimal) else value
+    cell_val = ws.cell(row=row, column=total_col, value=val)
+    cell_val.font = Font(bold=True)
+    cell_val.number_format = _CURRENCY_FMT
+    return row + 1
+
+
+def _find_total_column(columns: list[ColumnDef]) -> int:
+    for i, c in enumerate(columns, 1):
+        if c.key in ("total_price", "net_price", "item_total", "qty"):
+            return i
+    return len(columns)
+
+
+# ---------------------------------------------------------------------------
+# Procurement structured writer
+# ---------------------------------------------------------------------------
+
+def _write_procurement_structured(
+    ws: Any, doc: GAEBDocument, columns: list[ColumnDef]
+) -> None:
+    row = _write_header_row(ws, columns)
+
+    for lot in doc.award.boq.lots:
+        lot_label = f"Lot {lot.rno}"
+        if lot.label:
+            lot_label += f" — {lot.label}"
+        row = _write_label_row(ws, row, lot_label, columns)
+
+        for ctgy in lot.body.categories:
+            row = _write_procurement_category(ws, row, ctgy, columns, depth=1)
+
+        lot_total = float(lot.subtotal)
+        if lot_total:
+            row = _write_subtotal_row(ws, row, "Lot Subtotal", lot_total, columns)
+
+    grand = float(doc.grand_total)
+    if grand:
+        row = _write_subtotal_row(ws, row, "GRAND TOTAL", grand, columns)
+
+
+def _write_procurement_category(
+    ws: Any, row: int, ctgy: Any, columns: list[ColumnDef], depth: int
+) -> int:
+    indent = "  " * depth
+    label = f"{indent}{ctgy.rno}"
+    if ctgy.label:
+        label += f" — {ctgy.label}"
+    row = _write_label_row(ws, row, label, columns)
+
+    for item in ctgy.items:
+        row = _write_item_row(ws, row, item, columns)
+
+    for sub in ctgy.subcategories:
+        row = _write_procurement_category(ws, row, sub, columns, depth + 1)
+
+    subtotal = float(ctgy.subtotal)
+    if subtotal and (ctgy.items or ctgy.subcategories):
+        row = _write_subtotal_row(
+            ws, row, f"{indent}Subtotal {ctgy.rno}", subtotal, columns
+        )
+
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Trade structured writer
+# ---------------------------------------------------------------------------
+
+def _write_trade_structured(
+    ws: Any, doc: GAEBDocument, columns: list[ColumnDef]
+) -> None:
+    row = _write_header_row(ws, columns)
+
+    if doc.order is None:
+        return
+
+    for item in doc.order.items:
+        row = _write_item_row(ws, row, item, columns)
+
+    grand = float(doc.order.grand_total)
+    if grand:
+        row = _write_subtotal_row(ws, row, "TOTAL", grand, columns)
+
+
+# ---------------------------------------------------------------------------
+# Cost structured writer
+# ---------------------------------------------------------------------------
+
+def _write_cost_structured(
+    ws: Any, doc: GAEBDocument, columns: list[ColumnDef]
+) -> None:
+    row = _write_header_row(ws, columns)
+
+    if doc.elemental_costing is None:
+        return
+
+    ec = doc.elemental_costing
+    for ctgy in ec.body.categories:
+        row = _write_cost_category(ws, row, ctgy, columns, depth=0)
+
+    for ce in ec.body.cost_elements:
+        row = _write_cost_element(ws, row, ce, columns, depth=0)
+
+    grand = float(ec.grand_total)
+    if grand:
+        row = _write_subtotal_row(ws, row, "GRAND TOTAL", grand, columns)
+
+
+def _write_cost_category(
+    ws: Any, row: int, ctgy: Any, columns: list[ColumnDef], depth: int
+) -> int:
+    indent = "  " * depth
+    label = f"{indent}{ctgy.ele_no}"
+    if ctgy.description:
+        label += f" — {ctgy.description}"
+    row = _write_label_row(ws, row, label, columns)
+
+    if ctgy.body is not None:
+        for sub in ctgy.body.categories:
+            row = _write_cost_category(ws, row, sub, columns, depth + 1)
+        for ce in ctgy.body.cost_elements:
+            row = _write_cost_element(ws, row, ce, columns, depth + 1)
+
+    return row
+
+
+def _write_cost_element(
+    ws: Any, row: int, ce: Any, columns: list[ColumnDef], depth: int
+) -> int:
+    row = _write_item_row(ws, row, ce, columns)
+    for child in ce.children:
+        row = _write_cost_element(ws, row, child, columns, depth + 1)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Quantity structured writer
+# ---------------------------------------------------------------------------
+
+def _write_quantity_structured(
+    ws: Any, doc: GAEBDocument, columns: list[ColumnDef]
+) -> None:
+    row = _write_header_row(ws, columns)
+
+    if doc.qty_determination is None:
+        return
+
+    qd = doc.qty_determination
+    for ctgy in qd.boq.body.categories:
+        row = _write_qty_category(ws, row, ctgy, columns, depth=0)
+
+
+def _write_qty_category(
+    ws: Any, row: int, ctgy: Any, columns: list[ColumnDef], depth: int
+) -> int:
+    indent = "  " * depth
+    label = f"{indent}Category {ctgy.rno}"
+    row = _write_label_row(ws, row, label, columns)
+
+    for item in ctgy.items:
+        row = _write_item_row(ws, row, item, columns)
+
+    for sub in ctgy.subcategories:
+        row = _write_qty_category(ws, row, sub, columns, depth + 1)
+
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Flat items sheet (shared)
+# ---------------------------------------------------------------------------
+
+def _write_flat_items(
+    ws: Any, doc: GAEBDocument, columns: list[ColumnDef]
+) -> None:
+    row = _write_header_row(ws, columns)
+    for item in doc.iter_items():
+        row = _write_item_row(ws, row, item, columns)
+
+
+# ---------------------------------------------------------------------------
+# Summary sheet
+# ---------------------------------------------------------------------------
+
+def _write_summary_sheet(ws: Any, doc: GAEBDocument) -> None:
+    from openpyxl.styles import Font
+
+    headers = ["Metric", "Value"]
+    for col_idx, h in enumerate(headers, 1):
+        cell = ws.cell(row=1, column=col_idx, value=h)
+        cell.font = Font(bold=True)
+
+    row = 2
+
+    if doc.is_procurement:
+        for lot in doc.award.boq.lots:
+            lot_label = f"Lot {lot.rno}"
+            if lot.label:
+                lot_label += f" — {lot.label}"
+            ws.cell(row=row, column=1, value=lot_label)
+            ws.cell(row=row, column=2)
+            row += 1
+
+            item_count = sum(1 for _ in lot.iter_items())
+            ws.cell(row=row, column=1, value="  Items")
+            ws.cell(row=row, column=2, value=item_count)
+            row += 1
+
+            subtotal = float(lot.subtotal)
+            ws.cell(row=row, column=1, value="  Subtotal")
+            cell = ws.cell(row=row, column=2, value=subtotal)
+            cell.number_format = _CURRENCY_FMT
+            row += 1
+
+        row += 1
+
+    ws.cell(row=row, column=1, value="Total Items")
+    ws.cell(row=row, column=2, value=doc.item_count)
+    row += 1
+
+    cell_label = ws.cell(row=row, column=1, value="Grand Total")
+    cell_label.font = Font(bold=True)
+    cell_val = ws.cell(row=row, column=2, value=float(doc.grand_total))
+    cell_val.font = Font(bold=True)
+    cell_val.number_format = _CURRENCY_FMT
+
+
+# ---------------------------------------------------------------------------
+# Info sheet
+# ---------------------------------------------------------------------------
+
+def _write_info_sheet(ws: Any, doc: GAEBDocument) -> None:
+    from openpyxl.styles import Font
+
+    headers = ["Property", "Value"]
+    for col_idx, h in enumerate(headers, 1):
+        cell = ws.cell(row=1, column=col_idx, value=h)
+        cell.font = Font(bold=True)
+
+    info_rows: list[tuple[str, Any]] = [
+        ("Document Kind", doc.document_kind.value),
+        ("Exchange Phase", doc.exchange_phase.value),
+        ("Source Version", doc.source_version.value),
+        ("Source File", doc.source_file or ""),
+    ]
+
+    if doc.gaeb_info.prog_system:
+        info_rows.append(("Program System", doc.gaeb_info.prog_system))
+    if doc.gaeb_info.prog_system_version:
+        info_rows.append(("Program Version", doc.gaeb_info.prog_system_version))
+
+    if doc.is_procurement:
+        award = doc.award
+        if award.project_name:
+            info_rows.append(("Project Name", award.project_name))
+        if award.project_no:
+            info_rows.append(("Project No.", award.project_no))
+        if award.currency:
+            info_rows.append(("Currency", award.currency))
+        if award.client:
+            info_rows.append(("Client", award.client))
+
+    if doc.is_trade and doc.order is not None:
+        oi = doc.order.order_info
+        if oi is not None:
+            if oi.order_no:
+                info_rows.append(("Order No.", oi.order_no))
+            if oi.currency:
+                info_rows.append(("Currency", oi.currency))
+
+    if doc.is_cost and doc.elemental_costing is not None:
+        ec_info = doc.elemental_costing.ec_info
+        if ec_info.name:
+            info_rows.append(("Cost Estimation Name", ec_info.name))
+        if ec_info.currency:
+            info_rows.append(("Currency", ec_info.currency))
+
+    for row_idx, (prop, val) in enumerate(info_rows, 2):
+        ws.cell(row=row_idx, column=1, value=prop)
+        ws.cell(row=row_idx, column=2, value=str(val) if val else "")
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+def _apply_formatting(ws: Any, columns: list[ColumnDef]) -> None:
+    """Apply minimal formatting: column widths and frozen header."""
+    for col_idx, col_def in enumerate(columns, 1):
+        max_len = col_def.width
+        for row in ws.iter_rows(min_col=col_idx, max_col=col_idx, values_only=False):
+            for cell in row:
+                if cell.value is not None:
+                    max_len = max(max_len, min(len(str(cell.value)), _MAX_COL_WIDTH))
+        col_letter = _col_letter(col_idx)
+        ws.column_dimensions[col_letter].width = max(max_len + 2, _MIN_COL_WIDTH)
+
+    ws.freeze_panes = "A2"
+
+
+def _apply_formatting_auto(ws: Any) -> None:
+    """Auto-width for simple sheets (Summary, Info)."""
+    for col in ws.columns:
+        max_len = _MIN_COL_WIDTH
+        col_letter = col[0].column_letter
+        for cell in col:
+            if cell.value is not None:
+                max_len = max(max_len, min(len(str(cell.value)), _MAX_COL_WIDTH))
+        ws.column_dimensions[col_letter].width = max_len + 2
+
+    ws.freeze_panes = "A2"
+
+
+def _col_letter(col_idx: int) -> str:
+    from openpyxl.utils import get_column_letter
+    return get_column_letter(col_idx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest-asyncio",
     "xmldiff>=2.6",
     "lxml-stubs",
+    "openpyxl>=3.1",
 ]
 docs = [
     "mkdocs-material>=9.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+excel = ["openpyxl>=3.1"]
 llm = ["litellm>=1.40", "instructor>=1.0"]
 dev = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,10 @@ warn_unused_configs = true
 module = ["litellm", "litellm.*", "instructor", "instructor.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["openpyxl", "openpyxl.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/tests/test_excel_export.py
+++ b/tests/test_excel_export.py
@@ -1,0 +1,494 @@
+"""Tests for the Excel export feature."""
+
+from __future__ import annotations  # noqa: I001
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from pygaeb.convert.to_excel import to_excel
+from pygaeb.models.boq import BoQ, BoQBody, BoQCtgy, BoQInfo, Lot, Totals
+from pygaeb.models.cost import (
+    CostElement,
+    ECBody,
+    ECCtgy,
+    ECInfo,
+    ElementalCosting,
+)
+from pygaeb.models.document import AwardInfo, GAEBDocument, GAEBInfo
+from pygaeb.models.enums import (
+    ExchangePhase,
+    ItemType,
+    SourceVersion,
+)
+from pygaeb.models.item import ClassificationResult, Item
+from pygaeb.models.order import OrderInfo, OrderItem, TradeOrder
+from pygaeb.models.quantity import (
+    QtyBoQ,
+    QtyBoQBody,
+    QtyBoQCtgy,
+    QtyDetermination,
+    QtyItem,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+def _make_procurement_doc() -> GAEBDocument:
+    items_a = [
+        Item(oz="01.0010", short_text="Foundation", qty=Decimal("120"),
+             unit="m3", unit_price=Decimal("85"), total_price=Decimal("10200")),
+        Item(oz="01.0020", short_text="Columns", qty=Decimal("40"),
+             unit="m3", unit_price=Decimal("95"), total_price=Decimal("3800")),
+    ]
+    items_b = [
+        Item(oz="02.0010", short_text="Exterior walls", qty=Decimal("600"),
+             unit="m2", unit_price=Decimal("68"), total_price=Decimal("40800")),
+    ]
+    ctgy_a = BoQCtgy(rno="01", label="Concrete", items=items_a)
+    ctgy_b = BoQCtgy(rno="02", label="Masonry", items=items_b)
+    lot = Lot(rno="1", label="Structural Work",
+              body=BoQBody(categories=[ctgy_a, ctgy_b]),
+              totals=Totals(total=Decimal("54800")))
+    boq = BoQ(boq_info=BoQInfo(), lots=[lot])
+    award = AwardInfo(
+        boq=boq, project_name="Test Project", project_no="PRJ-001", currency="EUR"
+    )
+    return GAEBDocument(
+        source_version=SourceVersion.DA_XML_33,
+        exchange_phase=ExchangePhase.X83,
+        gaeb_info=GAEBInfo(prog_system="pyGAEB-Test"),
+        award=award,
+    )
+
+
+def _make_trade_doc() -> GAEBDocument:
+    items = [
+        OrderItem(
+            item_id="1", art_no="W-100", short_text="Window frame",
+            qty=Decimal("10"), unit="Stk",
+            offer_price=Decimal("250"), net_price=Decimal("230"),
+        ),
+        OrderItem(
+            item_id="2", art_no="D-200", short_text="Door panel",
+            qty=Decimal("5"), unit="Stk",
+            offer_price=Decimal("400"), net_price=Decimal("380"),
+            is_service=True,
+        ),
+    ]
+    order = TradeOrder(
+        dp="X96",
+        order_info=OrderInfo(order_no="ORD-001", currency="EUR"),
+        items=items,
+    )
+    return GAEBDocument(
+        source_version=SourceVersion.DA_XML_33,
+        exchange_phase=ExchangePhase.X96,
+        gaeb_info=GAEBInfo(),
+        order=order,
+    )
+
+
+def _make_cost_doc() -> GAEBDocument:
+    ce1 = CostElement(
+        ele_no="310", short_text="Walls", qty=Decimal("100"),
+        unit="m2", unit_price=Decimal("85"), item_total=Decimal("8500"),
+    )
+    ce2 = CostElement(
+        ele_no="320", short_text="Floors", qty=Decimal("200"),
+        unit="m2", unit_price=Decimal("65"), item_total=Decimal("13000"),
+    )
+    ctgy = ECCtgy(
+        ele_no="300", description="Building Construction",
+        body=ECBody(cost_elements=[ce1, ce2]),
+    )
+    ec = ElementalCosting(
+        dp="X50",
+        ec_info=ECInfo(name="Office Building", currency="EUR"),
+        body=ECBody(categories=[ctgy]),
+    )
+    return GAEBDocument(
+        source_version=SourceVersion.DA_XML_33,
+        exchange_phase=ExchangePhase.X50,
+        gaeb_info=GAEBInfo(),
+        elemental_costing=ec,
+    )
+
+
+def _make_qty_doc() -> GAEBDocument:
+    qi1 = QtyItem(oz="01.0010", rno_part="01", qty=Decimal("120"))
+    qi2 = QtyItem(oz="01.0020", rno_part="01", qty=Decimal("80"))
+    ctgy = QtyBoQCtgy(rno="01", items=[qi1, qi2])
+    qd = QtyDetermination(
+        dp="X31",
+        boq=QtyBoQ(body=QtyBoQBody(categories=[ctgy])),
+    )
+    return GAEBDocument(
+        source_version=SourceVersion.DA_XML_33,
+        exchange_phase=ExchangePhase.X31,
+        gaeb_info=GAEBInfo(),
+        qty_determination=qd,
+    )
+
+
+# ── Helper ──────────────────────────────────────────────────────────────
+
+def _load_workbook(path: Path):
+    import openpyxl
+    return openpyxl.load_workbook(path)
+
+
+# ── Procurement Tests ───────────────────────────────────────────────────
+
+class TestProcurementExport:
+    def test_structured_creates_file(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_structured_has_single_sheet(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        wb = _load_workbook(out)
+        assert len(wb.sheetnames) == 1
+        assert wb.sheetnames[0] == "BoQ"
+
+    def test_structured_contains_items(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        values = [row[0] for row in ws.iter_rows(values_only=True)]
+        assert "OZ" in values
+        assert any("Lot 1" in str(v) for v in values if v)
+
+    def test_structured_has_grand_total(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        all_vals = []
+        for row in ws.iter_rows(values_only=True):
+            all_vals.extend(row)
+        assert any("GRAND TOTAL" in str(v) for v in all_vals if v)
+
+    def test_full_mode_has_four_sheets(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="full")
+        wb = _load_workbook(out)
+        assert set(wb.sheetnames) == {"BoQ", "Items", "Summary", "Info"}
+
+    def test_full_items_sheet_has_all_items(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="full")
+        wb = _load_workbook(out)
+        ws = wb["Items"]
+        data_rows = list(ws.iter_rows(min_row=2, values_only=True))
+        assert len(data_rows) == 3
+
+    def test_full_info_sheet_has_metadata(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="full")
+        wb = _load_workbook(out)
+        ws = wb["Info"]
+        all_vals = []
+        for row in ws.iter_rows(values_only=True):
+            all_vals.extend(row)
+        assert "Test Project" in all_vals
+        assert "PRJ-001" in all_vals
+        assert "EUR" in all_vals
+
+    def test_full_summary_sheet(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="full")
+        wb = _load_workbook(out)
+        ws = wb["Summary"]
+        all_vals = []
+        for row in ws.iter_rows(values_only=True):
+            all_vals.extend(row)
+        assert "Grand Total" in all_vals
+        assert 3 in all_vals
+
+
+# ── Trade Tests ─────────────────────────────────────────────────────────
+
+class TestTradeExport:
+    def test_structured_creates_file(self, tmp_path: Path):
+        doc = _make_trade_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        assert out.exists()
+
+    def test_structured_has_trade_columns(self, tmp_path: Path):
+        doc = _make_trade_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        assert "Item ID" in headers
+        assert "Article No." in headers
+        assert "Net Price" in headers
+
+    def test_service_flag(self, tmp_path: Path):
+        doc = _make_trade_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        all_vals = []
+        for row in ws.iter_rows(values_only=True):
+            all_vals.extend(row)
+        assert "Yes" in all_vals
+
+    def test_full_mode(self, tmp_path: Path):
+        doc = _make_trade_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="full")
+        wb = _load_workbook(out)
+        assert "Items" in wb.sheetnames
+        ws = wb["Items"]
+        data_rows = list(ws.iter_rows(min_row=2, values_only=True))
+        assert len(data_rows) == 2
+
+
+# ── Cost Tests ──────────────────────────────────────────────────────────
+
+class TestCostExport:
+    def test_structured_creates_file(self, tmp_path: Path):
+        doc = _make_cost_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        assert out.exists()
+
+    def test_structured_has_cost_columns(self, tmp_path: Path):
+        doc = _make_cost_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        assert "Element No." in headers
+        assert "Total" in headers
+        assert "Markup" in headers
+
+    def test_structured_has_category_header(self, tmp_path: Path):
+        doc = _make_cost_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        all_vals = [row[0] for row in ws.iter_rows(values_only=True)]
+        assert any("Building Construction" in str(v) for v in all_vals if v)
+
+    def test_full_mode(self, tmp_path: Path):
+        doc = _make_cost_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="full")
+        wb = _load_workbook(out)
+        assert set(wb.sheetnames) == {"BoQ", "Items", "Summary", "Info"}
+
+
+# ── Quantity Tests ──────────────────────────────────────────────────────
+
+class TestQuantityExport:
+    def test_structured_creates_file(self, tmp_path: Path):
+        doc = _make_qty_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        assert out.exists()
+
+    def test_structured_has_qty_columns(self, tmp_path: Path):
+        doc = _make_qty_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="structured")
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        assert "OZ" in headers
+        assert "Determinations" in headers
+
+    def test_full_mode(self, tmp_path: Path):
+        doc = _make_qty_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, mode="full")
+        wb = _load_workbook(out)
+        assert "Items" in wb.sheetnames
+
+
+# ── Column Flags ────────────────────────────────────────────────────────
+
+class TestColumnFlags:
+    def test_include_long_text(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, include_long_text=True)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        assert "Long Text" in headers
+
+    def test_include_classification(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        for item in doc.award.boq.iter_items():
+            item.classification = ClassificationResult(
+                trade="Masonry", element_type="Wall", confidence=0.95
+            )
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, include_classification=True)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        assert "Trade" in headers
+        assert "Element Type" in headers
+        assert "Confidence" in headers
+
+    def test_include_bim_guid(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, include_bim_guid=True)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        assert "BIM GUID" in headers
+
+    def test_bim_guid_not_added_for_trade(self, tmp_path: Path):
+        doc = _make_trade_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out, include_bim_guid=True)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        assert "BIM GUID" not in headers
+
+
+# ── Formatting Tests ────────────────────────────────────────────────────
+
+class TestFormatting:
+    def test_header_row_is_bold(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        header_cell = ws.cell(row=1, column=1)
+        assert header_cell.font.bold is True
+
+    def test_freeze_panes(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        assert ws.freeze_panes == "A2"
+
+    def test_number_format_on_currency(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        for row in ws.iter_rows(min_row=2):
+            for cell in row:
+                if isinstance(cell.value, (int, float)) and cell.value > 100:
+                    assert cell.number_format in ('#,##0.00', '#,##0.###', 'General')
+                    break
+
+
+# ── Edge Cases ──────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    def test_empty_document(self, tmp_path: Path):
+        doc = GAEBDocument()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out)
+        assert out.exists()
+
+    def test_invalid_mode_raises(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        with pytest.raises(ValueError, match="Invalid mode"):
+            to_excel(doc, out, mode="invalid")
+
+    def test_multi_lot(self, tmp_path: Path):
+        items1 = [
+            Item(oz="01.0010", short_text="Item A", total_price=Decimal("100")),
+        ]
+        items2 = [
+            Item(oz="01.0010", short_text="Item B", total_price=Decimal("200")),
+        ]
+        lot1 = Lot(rno="1", label="Lot 1",
+                    body=BoQBody(categories=[BoQCtgy(rno="01", label="A", items=items1)]))
+        lot2 = Lot(rno="2", label="Lot 2",
+                    body=BoQBody(categories=[BoQCtgy(rno="01", label="B", items=items2)]))
+        boq = BoQ(lots=[lot1, lot2])
+        doc = GAEBDocument(award=AwardInfo(boq=boq))
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        all_vals = [row[0] for row in ws.iter_rows(values_only=True)]
+        assert any("Lot 1" in str(v) for v in all_vals if v)
+        assert any("Lot 2" in str(v) for v in all_vals if v)
+
+    def test_nested_subcategories(self, tmp_path: Path):
+        sub = BoQCtgy(rno="01.01", label="Sub", items=[
+            Item(oz="01.01.0010", short_text="Nested item", total_price=Decimal("50")),
+        ])
+        ctgy = BoQCtgy(rno="01", label="Main", subcategories=[sub])
+        lot = Lot(rno="1", label="L", body=BoQBody(categories=[ctgy]))
+        boq = BoQ(lots=[lot])
+        doc = GAEBDocument(award=AwardInfo(boq=boq))
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        all_vals = [row[0] for row in ws.iter_rows(values_only=True)]
+        assert any("Sub" in str(v) for v in all_vals if v)
+
+    def test_alternative_item_type(self, tmp_path: Path):
+        items = [
+            Item(oz="01.0010", short_text="Normal", item_type=ItemType.NORMAL),
+            Item(oz="01.0020", short_text="Alt", item_type=ItemType.ALTERNATIVE),
+        ]
+        ctgy = BoQCtgy(rno="01", label="A", items=items)
+        lot = Lot(rno="1", body=BoQBody(categories=[ctgy]))
+        doc = GAEBDocument(award=AwardInfo(boq=BoQ(lots=[lot])))
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out)
+        wb = _load_workbook(out)
+        ws = wb["BoQ"]
+        all_vals = []
+        for row in ws.iter_rows(values_only=True):
+            all_vals.extend(row)
+        assert "Alternative" in all_vals
+
+    def test_lazy_import(self):
+        from pygaeb import to_excel as te
+        assert te is to_excel
+
+
+# ── Path handling ───────────────────────────────────────────────────────
+
+class TestPathHandling:
+    def test_string_path(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = str(tmp_path / "test.xlsx")
+        to_excel(doc, out)
+        assert Path(out).exists()
+
+    def test_pathlib_path(self, tmp_path: Path):
+        doc = _make_procurement_doc()
+        out = tmp_path / "test.xlsx"
+        to_excel(doc, out)
+        assert out.exists()


### PR DESCRIPTION
…ent kinds

Supports structured (single sheet with lots/categories/subtotals) and full (BoQ + Items + Summary + Info) modes across procurement, trade, cost, and quantity phases. Phase-specific column profiles auto-selected via DocumentKind. Optional columns (long_text, classification, bim_guid) via include flags. openpyxl declared as optional dependency via pyGAEB[excel]. 34 new tests.